### PR TITLE
English and editorial review of the I-D.

### DIFF
--- a/draft-ietf-teas-actn-poi-applicability.md
+++ b/draft-ietf-teas-actn-poi-applicability.md
@@ -57,6 +57,10 @@ contributor:
     name: Gabriele Galimberti
     email: ggalimbe56@gmail.com
   -
+    name: To-Be-Added
+    org: To-Be-Added
+    email: To-Be-Added
+  -
     name: Anton Snitser
     org: Cisco
     email: asnizar@cisco.com
@@ -381,6 +385,8 @@ such as PE-BR, PE-P, BR-P, and P-P IP links. Consequently, inter-domain
 IP links are always single-technology connections, supported by
 single-technology Ethernet links between physically adjacent IP routers.
 
+As described in {{?RFC7424}, in order to increase the bandwidth between two adjacent routers multiple Ethernet links can be setup between adjacent routers using either Link Aggregation Groups (LAGs) {{IEEE_802.1AX}} or Equal Cost Multi-Path (ECMP) {{?RFC2991}}.
+
 Therefore, if inter-domain links between optical domains exist, they
 would be utilized to support multi-domain optical services, which fall
 outside the scope of this document.
@@ -511,7 +517,7 @@ reference to a precomputed SR policy or path.
 local protection mechanisms, such as Fast Reroute (FRR) for MPLS-TE or
 Topology Independent Loop-Free Alternate (TI-LFA) for SR-TE. These
 mechanisms operate with an awareness of multi-technology TE path
-properties, such as Shared Risk Link Group (SRLG).
+properties, such as the Shared Risk Link Group (SRLG) path properties defined in {{?RFC8001}}.
 
 For inter-domain TE paths, it is assumed that each packet domain in
 {{fig-vpn-topo}} and {{fig-vpn-path}} employs the same TE technology. The
@@ -1071,7 +1077,7 @@ In particular, for the cross-technology Ethernet links, it is key for
 MDSC to
 automatically correlate the information from the PNC network
 databases about the physical ports from the routers (single link or
-bundle links for Link Aggregation Group (LAG)) to client ports in the
+bundle links for LAG) to client ports in the
 ROADM.
 
 The analysis of multi-layer fault management is outside the scope of
@@ -1751,8 +1757,7 @@ connected to PE13 and P16, as described in
 {{multi-technology-link-setup}};
 
 - the P-PNC1 to update the configuration of the existing IP link, in
-case of LAG, or configure a new IP link, in case of Equal Cost Multi-Path
-(ECMP), between
+case of LAG, or configure a new IP link, in case of ECMP, between
 PE13 and P16, as described in {{multi-technology-link-setup}};
 
 - the P-PNC1 to update the bandwidth of the selected TE path between

--- a/draft-ietf-teas-actn-poi-applicability.md
+++ b/draft-ietf-teas-actn-poi-applicability.md
@@ -138,8 +138,8 @@ Network Controller Interface (MPI) within the ACTN architecture
 # Introduction
 
 The full automation of management and control for Service Providers'
-transport  networks�spanning IP/MPLS, optical, and microwave
-technologies�is crucial to addressing customer demands for high-bandwidth
+transport  networks, spanning IP/MPLS, optical, and microwave
+technologies, is crucial to addressing customer demands for high-bandwidth
 applications, such as ultra-fast  mobile broadband for 5G and fiber
 connectivity services. The Abstraction and  Control of TE Networks (ACTN)
 architecture and interfaces enable the automation  and efficient
@@ -151,10 +151,8 @@ such as physical diversity, latency, bandwidth, and topology.
 
 Packet Optical Integration (POI) represents an advanced application of
 traffic engineering. In wide-area networks, packet networks based on the
-
 Internet Protocol (IP), often augmented with Multiprotocol Label
 Switching (MPLS) or Segment Routing  (SR), are typically implemented over
-
 an optical transport network utilizing Dense Wavelength Division
 Multiplexing (DWDM), occasionally with an optional Optical Transport
 Network (OTN) layer.
@@ -190,7 +188,6 @@ This document uses packet-based Traffic Engineered (TE) service
 examples. These are described as "TE-path" in this document. Unless
 otherwise stated, these TE services may be instantiated using
 Resource Reservation Protocol (RSVP) Traffic Engineering (TE)-based or SR
-
 -TE-based, forwarding plane mechanisms.
 
 The ACTN framework facilitates seamless integration of packet and optical
@@ -243,11 +240,9 @@ Customer service:
 
 Network service:
 : The Provider Edge (PE) to PE configuration, including both the network
-
 service layer (VRFs, RT import/export policies configuration) and the
 network transport layer (e.g. RSVP-TE Label Switched Paths (LSPs). This
 includes the configuration (on the PE side) of the interface towards the
-
 CE (e.g. VLAN, IP address, routing protocol, etc.).
 
 Technology domain:
@@ -333,6 +328,7 @@ domain, while each Optical PNC (O-PNC) is tasked with managing its
 optical domain. The packet domains controlled by the P-PNCs can represent
 Autonomous Systems (ASes), as defined in {{?RFC1930}}, or Interior
 Gateway Protocol (IGP) areas within the same operator network.
+
 The IP routers between the packet domains can be either AS Boundary
 Routers (ASBR) or Area Border Router (ABR): in this document, the
 generic term Border Router (BR) is used to represent either an ASBR
@@ -357,7 +353,7 @@ In the reference network of {{fig-ref-network}}, it is assumed that:
 
 - The domain boundaries of the packet and optical domains are
 congruent. In other words, each optical domain exclusively supports
-connectivity between IP routers within a single packet domain.;
+connectivity between IP routers within a single packet domain.
 
 - There are no physical links directly connecting optical domains.
 Inter-domain physical links exist only under the following conditions:
@@ -377,12 +373,7 @@ Inter-domain physical links exist only under the following conditions:
 -  All the physical interfaces at inter-domain links are Ethernet
 physical interfaces.
 
-Although emerging optical technologies (e.g., QSFP-DD ZR 400G) enable
-operators to deploy DWDM pluggable interfaces on IP routers, the adoption
-of these technologies remains limited. This is primarily because most
-operators are not yet prepared to manage packet and optical networks
-within a single unified domain. Consequently, a unified use case analysis
-falls outside the scope of this document.
+Scenarios using coherent optical interfaces on the IP routers are outside the scope of this document.
 
 This document analyzes scenarios in which all multi-technology IP links
 supported by the optical network are intra-domain (intra-AS/intra-area),
@@ -396,7 +387,7 @@ outside the scope of this document.
 
 The optical nodes within the optical domains can be either:
 
-- DWDM nodes, as defined in
+- WDM nodes, as defined in
 {{?I-D.ietf-ccamp-optical-impairment-topology-yang}}, with an integrated
 ROADM functions and with or without integrated optical transponders;
 
@@ -550,9 +541,7 @@ other services (e.g. VPN).
 
    1.  Hard isolation with deterministic latency implies that the L2/L3
        VPN requires a set of dedicated TE tunnels. These tunnels neither
-
        share resources with other services nor compete for bandwidth with
-
        other tunnels, ensuring deterministic latency performance.
 
    1.  Hard isolation but without deterministic characteristics
@@ -800,7 +789,7 @@ the scope of this document.
 
 Depending on the optical network type, TE topology abstraction, path
 computation, and path setup can be single-layer (either OTN or DWDM)
-or multi-layer OTN/WDM. In the latter case, multi-layer coordination
+or multi-layer OTN/DWDM. In the latter case, multi-layer coordination
 between the OTN and DWDM layers is handled by the O-PNC.
 
 {: #mpi}
@@ -1076,7 +1065,7 @@ inventory/topology/service change occurs.
 
 It should also be possible to correlate information from IP and
 optical layers (e.g., which port, lambda/OTSi, and direction are used
-by a specific IP service on the DWDM equipment).
+by a specific IP service on the WDM node).
 
 In particular, for the cross-technology Ethernet links, it is key for
 MDSC to
@@ -1101,7 +1090,7 @@ notifications.
 ## Optical Topology Discovery
 
 The WSON Topology Model and the Flexi-grid Topology model can be used
-to report the DWDM network topology (e.g., DWDM nodes and OMS links),
+to report the DWDM network topology (e.g., WDM nodes and OMS links),
 depending on whether the DWDM optical network is based on fixed-grid
 or flexible-grid or a mix of fixed-grid and flexible-grid.
 
@@ -1174,10 +1163,10 @@ The optical transponders and, optionally, the OTN access cards, are
 abstracted at MPI by the O-PNC as Trail Termination Points (TTPs),
 defined in {{!RFC8795}}, within the optical network topology. This
 abstraction is valid independently of the fact that optical
-transponders are physically integrated within the same DWDM node or
-are physically located on a device external to the DWDM node since it
-both cases the optical transponders and the DWDM node are under the
-control of the same O-PNC and abstracted as a single DWDM TE Node at the
+transponders are physically integrated within the same WDM node or
+are physically located on a device external to the WDM node since it
+both cases the optical transponders and the WDM node are under the
+control of the same O-PNC and abstracted as a single WDM TE Node at the
 O-MPI.
 
 The association between the Ethernet or CBR client LTPs terminating
@@ -1199,7 +1188,7 @@ mechanisms which are outside the scope of this document, and reported
 at the MPIs within the optical network topology.
 
 In case of a multi-layer DWDM/OTN network domain, multi-layer
-intra-domain OTN links are supported by underlay DWDM tunnels: this
+intra-domain OTN links are supported by underlay WDM tunnels: this
 relationship is reported by the mechanisms described in
 {{optical-path-discovery}}.
 
@@ -1207,7 +1196,7 @@ relationship is reported by the mechanisms described in
 
 ## Optical Path Discovery
 
-The DWDM Tunnel Model is used to report all the DWDM tunnels
+The WDM Tunnel Model is used to report all the WDM tunnels
 established within the optical network.
 
 When the OTN switching layer is deployed within the optical domain,
@@ -1218,15 +1207,15 @@ The Ethernet client signal model and the Transparent CBR client
 signal model are used to report all the connectivity services
 provided by the underlay optical tunnels between Ethernet or CBR
 client LTPs, depending on whether the connectivity service is frame-based
-or transparent. The underlay optical tunnels can be either DWDM
+or transparent. The underlay optical tunnels can be either WDM
 tunnels or, when the optional OTN switching layer is deployed, OTN
 tunnels.
 
-The DWDM tunnels can be used to support either Ethernet or CBR client
+The WDM tunnels can be used to support either Ethernet or CBR client
 signals or multi-layer intra-domain OTN links. In the latter case,
 the hierarchical-link container, defined in {{!I-D.ietf-teas-yang-te}},
 associates
-the underlay DWDM tunnel with the supported multi-layer intra-domain
+the underlay WDM tunnel with the supported multi-layer intra-domain
 OTN link and it allows discovery of the multi-layer path supporting
 all the connectivity services provided by the optical network.
 
@@ -1840,7 +1829,7 @@ underlay optical tunnel.
 
 Therefore, to set up a new multi-technology intra-domain IP link,
 the MDSC requires the O-PNC to set up the optical tunnel (using either
-the DWDM Tunnel model or the OTN Tunnel model, if optional OTN switching
+the WDM Tunnel model or the OTN Tunnel model, if optional OTN switching
 is supported) within the optical network and steer client traffic
 between the two cross-technology Ethernet links over that optical tunnel,
 using either the Ethernet Client Signal Model (for frame-based transport)
@@ -1990,7 +1979,7 @@ of:
 SRLGs reported by the P-PNC using the packet TE topology model);
 
 - the optical path (e.g., the list of SRLGs reported by the O-PNC
-using the DWDM or OTN tunnel model); and
+using the WDM or OTN tunnel model); and
 
 - the cross-domain links (e.g., the list of SRLGs reported by the O-PNC
 and P-PNC respectively, using the WSON and/or flexi-grid, the
@@ -2108,7 +2097,7 @@ of this draft.
 # Conclusions
 
 The analysis provided in this document shows that the IETF YANG models
-described in 3.2 provide useful support for Packet Optical Integration
+described in {{yang}} provide useful support for Packet Optical Integration
 (POI) scenarios for resource discovery (network topology, service,
 tunnels, and network inventory discovery), as well as for supporting
 multi-layer/multi-domain L2/L3 VPN network services.
@@ -2164,7 +2153,7 @@ flexible-grid DWDM network topologies but also the only viable option
 for a mixed CWDM and DWDM network topology.
 
 Although not applicable to this document, it has been noted that the
-DWDM tunnel model would also support optical tunnel setup in the case
+WDM tunnel model would also support optical tunnel setup in the case
 of a mixed CWDM and DWDM network topology.
 
 Although not analyzed in this document, it has been noted that the TE
@@ -2429,17 +2418,17 @@ There can be two cases here:
 
 1. LAG was defined between the IP routers at the two ends. MDSC, after
 checking
-that optical layer is fine between the two edge DWDM nodes, triggers
-the DWDM edge node re-configuration so that the IP router's back-up port
+that optical layer is fine between the two edge WDM nodes, triggers
+the WDM edge node re-configuration so that the IP router's back-up port
 with its
-associated muxponder port can reuse the DWDM tunnel that was already in
+associated muxponder port can reuse the WDM tunnel that was already in
 use previously by the failed IP router port and adds the new link to
 the LAG on the failure side.
 
    While the ROADM reconfiguration takes place, IP/MPLS traffic is
    using the reduced bandwidth of the IP link bundle, discarding
    lower priority traffic if required. Once back-up port has been
-   reconfigured to reuse the existing DWDM tunnel and the new link has
+   reconfigured to reuse the existing WDM tunnel and the new link has
 been added
    to the LAG then original Bandwidth is recovered between the end
    routers.
@@ -2455,11 +2444,11 @@ or TI-LFA (MPLS based SR-TE case) through a protection port. At
 the same time MDSC, after checking that optical network connection
 is still fine, would trigger the reconfiguration of the back-up
 port of the IP router and of the muxponder to re-use the same
-DWDM tunnel as the one used originally for the failed IP router port. Once
+WDM tunnel as the one used originally for the failed IP router port. Once
 everything has been correctly configured, MDSC Global PCE could
 suggest to the operator to trigger a possible re-optimization of
 the back-up MPLS path to go back to the  MPLS primary path through
-the back-up port of the IP router and the original DWDM tunnel if overall
+the back-up port of the IP router and the original WDM tunnel if overall
 cost, latency etc. is improved. However, in this scenario, there
 is a need for protection port PLUS back-up port in the IP router
 which does not lead to clear port savings.
@@ -2477,7 +2466,7 @@ trunk port bit rate which will also determine the Baud-rate, the
 modulation format, the FEC etc.
 
 The controller, when asked to set up a client connectivity service,
-needs to find a DWDM tunnel suitable to comply the DWDM port
+needs to find a WDM tunnel suitable to comply the DWDM port
 parameters.
 
 The setup of a client connectivity service between two muxponders is
@@ -2487,20 +2476,20 @@ might be a 100Gb/s trunk port shared by ten 10GE client ports.
 
 The controller, when asked to set a 10GE client connectivity service
 between two muxponder's client ports, needs first to check whether
-there is already an existing DWDM tunnel between the two muxponders
+there is already an existing WDM tunnel between the two muxponders
 and then take different actions:
 
-1. if the DWDM tunnel already exists, the controller needs only to
+1. if the WDM tunnel already exists, the controller needs only to
 enable the 10GE client ports to establish the 10GE client
 connectivity service;
 
-2. if the DWDM tunnel does not exist, the controller has to first
-establish the DWDM tunnel, finding a proper optical path matching
+2. if the WDM tunnel does not exist, the controller has to first
+establish the WDM tunnel, finding a proper optical path matching
 the optical parameters of the two muxponders' trunk ports (e.g.,
 an OTSi carrying an OTU4), and then enable the 10GE client ports
 to establish the 10GE client connectivity service.
 
-Since multiple client connectivity services are sharing the same DWDM
+Since multiple client connectivity services are sharing the same WDM
 tunnel, a multiplexing label shall be assigned to each client
 connectivity service. The multiplexing label can either be a standard
 label (e.g., an OTN timeslot) or a vendor-specific label. The
@@ -2519,7 +2508,7 @@ the control of the same O-PNC, the configuration of the multiplexing
 label, regardless of whether it is a standard or vendor-specific
 label, can be done by the O-PNC using mechanisms which are
 vendor-specific and outside the scope of this document. The MDSC can just
-request the O-PNC to setup a client connectivity service over a DWDM
+request the O-PNC to setup a client connectivity service over a WDM
 tunnel.
 
 In case of fixed configuration, the multiplexing label is assigned by

--- a/draft-ietf-teas-actn-poi-applicability.md
+++ b/draft-ietf-teas-actn-poi-applicability.md
@@ -6,8 +6,7 @@ abbrev: ACTN POI
 category: info
 
 docname: draft-ietf-teas-actn-poi-applicability-latest
-submissiontype: IETF  # also: "independent", "editorial", "IAB", or
-"IRTF"
+submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
 number:
 date:
 consensus: true
@@ -24,9 +23,7 @@ venue:
   mail: "teas@ietf.org"
   arch: "https://mailarchive.ietf.org/arch/browse/teas/"
   github: "IETF-TEAS-WG/actn-poi"
-  latest:
-"https://IETF-TEAS-WG.github.io/actn-poi/draft-ietf-teas-actn-poi-applica
-bility.html"
+  latest: "https://IETF-TEAS-WG.github.io/actn-poi/draft-ietf-teas-actn-poi-applicability.html"
 
 author:
   -
@@ -111,8 +108,7 @@ normative:
     seriesinfo: IEEE 802.1AB-2016
     target: https://ieeexplore.ieee.org/document/7433915
   IEEE_802.1AX:
-    title: "IEEE Standard for Local and metropolitan area networks - Link
-Aggregation"
+    title: "IEEE Standard for Local and metropolitan area networks - Link Aggregation"
     author:
       org: Institute of Electrical and Electronics Engineers
     date: December 2014
@@ -123,16 +119,16 @@ informative:
 
 --- abstract
 
-This document explores the applicability of the Abstraction and Control 
-of TE Networks (ACTN) architecture to Packet Optical Integration (POI) 
-within the context of IP/MPLS and optical internetworking. It examines 
-the YANG data models defined by the IETF that enable an ACTN-based 
-deployment architecture and highlights specific scenarios pertinent 
+This document explores the applicability of the Abstraction and Control
+of TE Networks (ACTN) architecture to Packet Optical Integration (POI)
+within the context of IP/MPLS and optical internetworking. It examines
+the YANG data models defined by the IETF that enable an ACTN-based
+deployment architecture and highlights specific scenarios pertinent
 to Service Providers.
 
-Existing IETF protocols and data models are identified for each 
-multi-technology scenario (packet over optical), particularly 
-emphasising the Multi-Domain Service Coordinator to Provisioning 
+Existing IETF protocols and data models are identified for each
+multi-technology scenario (packet over optical), particularly
+emphasising the Multi-Domain Service Coordinator to Provisioning
 Network Controller Interface (MPI) within the ACTN architecture
 
 --- middle
@@ -142,12 +138,12 @@ Network Controller Interface (MPI) within the ACTN architecture
 # Introduction
 
 The full automation of management and control for Service Providers'
-transport  networks—spanning IP/MPLS, optical, and microwave
-technologies—is crucial to addressing customer demands for high-bandwidth
+transport  networksï¿½spanning IP/MPLS, optical, and microwave
+technologiesï¿½is crucial to addressing customer demands for high-bandwidth
 applications, such as ultra-fast  mobile broadband for 5G and fiber
 connectivity services. The Abstraction and  Control of TE Networks (ACTN)
 architecture and interfaces enable the automation  and efficient
-operation of complex optical and IP/MPLS networks using standardized 
+operation of complex optical and IP/MPLS networks using standardized
 interfaces and data models. This approach supports a broad spectrum of
 network  services that can be requested by upper-layer applications,
 meeting diverse  service-level requirements from a network perspective,
@@ -156,11 +152,11 @@ such as physical diversity, latency, bandwidth, and topology.
 Packet Optical Integration (POI) represents an advanced application of
 traffic engineering. In wide-area networks, packet networks based on the
 
-Internet Protocol (IP), often augmented with Multiprotocol Label 
+Internet Protocol (IP), often augmented with Multiprotocol Label
 Switching (MPLS) or Segment Routing  (SR), are typically implemented over
 
-an optical transport network utilizing Dense Wavelength Division 
-Multiplexing (DWDM), occasionally with an optional Optical Transport 
+an optical transport network utilizing Dense Wavelength Division
+Multiplexing (DWDM), occasionally with an optional Optical Transport
 Network (OTN) layer.
 
 In many existing network deployments, packet and optical networks are
@@ -249,7 +245,7 @@ Network service:
 : The Provider Edge (PE) to PE configuration, including both the network
 
 service layer (VRFs, RT import/export policies configuration) and the
-network transport layer (e.g. RSVP-TE Label Switched Paths (LSPs). This 
+network transport layer (e.g. RSVP-TE Label Switched Paths (LSPs). This
 includes the configuration (on the PE side) of the interface towards the
 
 CE (e.g. VLAN, IP address, routing protocol, etc.).
@@ -609,50 +605,50 @@ beyond the scope of this document.
 When establishing a new TE path, the MDSC is responsible for coordinating
 the path computation across multiple layers and domains.
 
-Based on the MDSC's knowledge of the underlying network topology and 
-configuration, three approaches for multi-layer and multi-domain path 
+Based on the MDSC's knowledge of the underlying network topology and
+configuration, three approaches for multi-layer and multi-domain path
 computation are possible:
 
 1. Full Summarization: In this approach, the MDSC maintains an abstracted
 TE topology view of all its packet and optical underlying domains.
 
-   In this case, the MDSC lacks sufficient TE topology information to 
-   perform multi-layer/multi-domain path computation. It delegates the 
-   P-PNCs and O-PNCs to compute local paths within their respective 
-   domains, then uses the returned information to compute the optimal 
+   In this case, the MDSC lacks sufficient TE topology information to
+   perform multi-layer/multi-domain path computation. It delegates the
+   P-PNCs and O-PNCs to compute local paths within their respective
+   domains, then uses the returned information to compute the optimal
    multi-domain/multi-layer path.
 
-   This approach presents an issue for the P-PNC, as it lacks the ability 
-   to perform single-domain/multi-layer path computation. It cannot 
-   retrieve topology information from the O-PNCs or delegate optical path 
-   computation to the O-PNCs. A possible solution is to include a CNC 
-   function within the P-PNC to request the MDSC for multi-domain 
+   This approach presents an issue for the P-PNC, as it lacks the ability
+   to perform single-domain/multi-layer path computation. It cannot
+   retrieve topology information from the O-PNCs or delegate optical path
+   computation to the O-PNCs. A possible solution is to include a CNC
+   function within the P-PNC to request the MDSC for multi-domain
    optical path computation, as shown in Figure 10 of {{!RFC8453}}.
 
-   Another solution could involve relying on the MDSC recursive hierarchy, 
-   as defined in Section 4.1 of {{!RFC8453}}, where each IP and optical 
-   domain pair has a "lower-level MDSC" (MDSC-L) for multi-layer 
-   correlation, and a "higher-level MDSC" (MDSC-H) for multi-domain 
+   Another solution could involve relying on the MDSC recursive hierarchy,
+   as defined in Section 4.1 of {{!RFC8453}}, where each IP and optical
+   domain pair has a "lower-level MDSC" (MDSC-L) for multi-layer
+   correlation, and a "higher-level MDSC" (MDSC-H) for multi-domain
    coordination.
 
-   In this case, the MDSC-H obtains an abstract view of the underlying 
-   multi-layer domain topologies from its MDSC-L. Each MDSC-L gets the 
-   full IP domain topology from the P-PNC and an abstracted view of the 
-   optical domain topology from its O-PNC. Topology abstraction occurs 
-   at the MPIs between MDSC-L and O-PNC, as well as between MDSC-L and 
+   In this case, the MDSC-H obtains an abstract view of the underlying
+   multi-layer domain topologies from its MDSC-L. Each MDSC-L gets the
+   full IP domain topology from the P-PNC and an abstracted view of the
+   optical domain topology from its O-PNC. Topology abstraction occurs
+   at the MPIs between MDSC-L and O-PNC, as well as between MDSC-L and
    MDSC-H.
 
 1. Partial summarization: In this approach, the MDSC has complete
 visibility of the TE topology of the packet network domains and an
 abstracted view of the TE topology of the optical network domains.
 
-   The MDSC can then only perform multi-domain/single-layer path 
-   computation for the packet layer, where the path can be computed 
+   The MDSC can then only perform multi-domain/single-layer path
+   computation for the packet layer, where the path can be computed
    optimally for the two packet domains.
 
-   The MDSC still needs to delegate the O-PNCs to perform local path 
-   computation within their domains. It uses the information from the 
-   O-PNCs and its TE topology view of the multi-domain packet layer to 
+   The MDSC still needs to delegate the O-PNCs to perform local path
+   computation within their domains. It uses the information from the
+   O-PNCs and its TE topology view of the multi-domain packet layer to
    perform multi-layer/multi-domain path computation.
 
 1. Full knowledge: In this approach, the MDSC has a complete and
@@ -663,69 +659,69 @@ enough detailed view of the TE topology of all the network domains
    multi-domain/multi-layer path computation without relying on PNCs.
 
    This approach, however, may present scalability issues. As discussed
-in 
+in
    Section 2.2 of {{!I-D.ietf-teas-yang-path-computation}}, performing
-path 
+path
    computation for optical networks in the MDSC is particularly
-challenging, 
-   as optimal paths also depend on vendor-specific optical attributes, 
+challenging,
+   as optimal paths also depend on vendor-specific optical attributes,
    which may vary across domains if provided by different vendors.
 
-This document examines scenarios where the MDSC adopts the partial 
-summarization approach to enable multi-domain and multi-layer path 
+This document examines scenarios where the MDSC adopts the partial
+summarization approach to enable multi-domain and multi-layer path
 computation.
 
-Typically, O-PNCs are responsible for optical path computation within 
-their respective domains. When setting up a network service, they must 
-consider connection requirements such as bandwidth, amplification, 
-wavelength continuity, and non-linear impairments that may impact the 
+Typically, O-PNCs are responsible for optical path computation within
+their respective domains. When setting up a network service, they must
+consider connection requirements such as bandwidth, amplification,
+wavelength continuity, and non-linear impairments that may impact the
 network service path.
 
-The methods and types of path requirements and impairments, such as 
-those detailed in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}}, 
-used by the O-PNC for optical path computation are not exposed at the 
+The methods and types of path requirements and impairments, such as
+those detailed in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}},
+used by the O-PNC for optical path computation are not exposed at the
 MPI and therefore out of scope for this document.
 
 {: #packet-pnc-overview}
 
 ## IP/MPLS Domain Controller and IP router Functions
 
-Each packet domain in {{fig-ref-network}}, corresponding to either an 
-IGP area or an Autonomous System (AS) within the same operator network, 
+Each packet domain in {{fig-ref-network}}, corresponding to either an
+IGP area or an Autonomous System (AS) within the same operator network,
 is controlled by a packet domain controller (P-PNC).
 
-P-PNCs are responsible for establishing TE paths between any two PEs 
-or BRs within their controlled domains, as requested by the MDSC. They 
-also provide topology information to the MDSC to enable efficient 
+P-PNCs are responsible for establishing TE paths between any two PEs
+or BRs within their controlled domains, as requested by the MDSC. They
+also provide topology information to the MDSC to enable efficient
 network coordination.
 
-For example, in inter-domain SR-TE, setting up a bidirectional 
-SR-TE path from PE13 in Domain 1 to PE23 in Domain 2, as shown in 
+For example, in inter-domain SR-TE, setting up a bidirectional
+SR-TE path from PE13 in Domain 1 to PE23 in Domain 2, as shown in
 {{fig-vpn-path}}, requires the MDSC to coordinate the following actions:
 
-- P-PNC1: Push a SID list to PE13, including the Binding SID 
-  associated with the SR-TE path in Domain 2, with PE23 as the target 
+- P-PNC1: Push a SID list to PE13, including the Binding SID
+  associated with the SR-TE path in Domain 2, with PE23 as the target
   destination (forward direction).
 
-- P-PNC2: Push a SID list to PE23, including the Binding SID 
-  associated with the SR-TE path in Domain 1, with PE13 as the target 
+- P-PNC2: Push a SID list to PE23, including the Binding SID
+  associated with the SR-TE path in Domain 1, with PE13 as the target
   destination (reverse direction).
 
-With reference to {{fig-p-pnc}}, P-PNCs are responsible for the 
+With reference to {{fig-p-pnc}}, P-PNCs are responsible for the
 following:
 
 1. To expose to MDSC their respective detailed TE topology
 
-1. To perform single-layer, single-domain local TE path computation, 
-when requested by the MDSC, between two PEs (for single-domain 
-end-to-end TE path) or between PEs and BRs for an inter-domain TE 
+1. To perform single-layer, single-domain local TE path computation,
+when requested by the MDSC, between two PEs (for single-domain
+end-to-end TE path) or between PEs and BRs for an inter-domain TE
 path selected by the MDSC.
 
 1. To configure the routers in their respective domain to setup a TE
 path;
 
-1. To configure the VRF and PE-CE interfaces (Service access points) 
-for the intra-domain and inter-domain network services requested by 
+1. To configure the VRF and PE-CE interfaces (Service access points)
+for the intra-domain and inter-domain network services requested by
 the MDSC.
 
 ~~~~ ascii-art
@@ -750,10 +746,10 @@ the MDSC.
 ~~~~
 {: #fig-p-pnc title="Domain Controller & node Functions"}
 
-When requesting a new TE path setup, the MDSC provides the P-PNCs 
-with the explicit path to be created or modified. In other words, the 
-MDSC communicates the complete list of nodes involved in the path 
-(strict mode). The P-PNC is then responsible for setting up the 
+When requesting a new TE path setup, the MDSC provides the P-PNCs
+with the explicit path to be created or modified. In other words, the
+MDSC communicates the complete list of nodes involved in the path
+(strict mode). The P-PNC is then responsible for setting up the
 explicit TE path. For example:
 
 - with SR-TE, the P-PNC pushes to headend PE or BR the list of SIDs
@@ -762,91 +758,91 @@ to create the explicit SR-TE path, provided by the MDSC;
 - with RSVP-TE, the P-PNC requests the headend PE or BR to start
 signaling the explicit RSVP-TE path, provided by the MDSC.
 
-To scale in large SR-TE packet domains, the MDSC can provide the P-PNC 
-with a loose path and per-domain TE constraints. The P-PNC can then 
+To scale in large SR-TE packet domains, the MDSC can provide the P-PNC
+with a loose path and per-domain TE constraints. The P-PNC can then
 select the complete path within its domain.
 
-In this case, it is mandatory for the P-PNC to signal back to the MDSC 
-which path it has chosen, allowing the MDSC to track relevant 
+In this case, it is mandatory for the P-PNC to signal back to the MDSC
+which path it has chosen, allowing the MDSC to track relevant
 resource utilization.
 
-From the {{fig-vpn-path}} example, the TE path requested by the MDSC 
-touches PE13 - P16 - BR12 - BR21 - PE23. P-PNC2 is aware of two 
-paths with the same topology metric, e.g., BR21 - P24 - PE23 and 
-BR21 - BR22 - PE23, but with different loads. It may prefer to steer 
+From the {{fig-vpn-path}} example, the TE path requested by the MDSC
+touches PE13 - P16 - BR12 - BR21 - PE23. P-PNC2 is aware of two
+paths with the same topology metric, e.g., BR21 - P24 - PE23 and
+BR21 - BR22 - PE23, but with different loads. It may prefer to steer
 traffic on the latter as it is less loaded.
 
-For the purposes of this document, it is assumed that the MDSC always 
-provides the explicit list of all hops to the P-PNCs to set up or 
+For the purposes of this document, it is assumed that the MDSC always
+provides the explicit list of all hops to the P-PNCs to set up or
 modify the TE path.
 
 {: #optical-pnc-overview}
 
 ## Optical Domain Controller and NE Functions
 
-The optical network provides underlay connectivity services to 
-IP/MPLS networks. The packet and optical multi-layer coordination 
+The optical network provides underlay connectivity services to
+IP/MPLS networks. The packet and optical multi-layer coordination
 is handled by the MDSC, as shown in {{fig-ref-network}}.
 
 The O-PNC is responsible to:
 
-- Provide the MDSC with an abstract TE topology view of its underlying 
+- Provide the MDSC with an abstract TE topology view of its underlying
   optical network resources;
 
-- perform single-domain local path computation when requested by 
+- perform single-domain local path computation when requested by
   the MDSC;
 
 - Perform optical tunnel set up when requested by the MDSC.
 
-The mechanisms used by the O-PNC to perform intra-domain topology 
-discovery and path setup are typically vendor-specific and outside 
+The mechanisms used by the O-PNC to perform intra-domain topology
+discovery and path setup are typically vendor-specific and outside
 the scope of this document.
 
-Depending on the optical network type, TE topology abstraction, path 
-computation, and path setup can be single-layer (either OTN or DWDM) 
-or multi-layer OTN/WDM. In the latter case, multi-layer coordination 
+Depending on the optical network type, TE topology abstraction, path
+computation, and path setup can be single-layer (either OTN or DWDM)
+or multi-layer OTN/WDM. In the latter case, multi-layer coordination
 between the OTN and DWDM layers is handled by the O-PNC.
 
 {: #mpi}
 
 # Interface Protocols and YANG Data Models for the MPIs
 
-This section describes general assumptions applicable to all MPI 
-interfaces between each PNC (Optical or Packet) and the MDSC, to 
+This section describes general assumptions applicable to all MPI
+interfaces between each PNC (Optical or Packet) and the MDSC, to
 support the scenarios discussed in this document.
 
 {: #restconf}
 
 ## RESTCONF Protocol at the MPIs
 
-The RESTCONF protocol, as defined in {{!RFC8040}}, using the JSON 
-representation from {{!RFC7951}}, is assumed to be used at these 
-interfaces. Additionally, extensions to RESTCONF, as defined in 
-{{!RFC8527}}, to comply with the Network Management Datastore 
-Architecture (NMDA) from {{!RFC8342}}, are assumed to be used at 
+The RESTCONF protocol, as defined in {{!RFC8040}}, using the JSON
+representation from {{!RFC7951}}, is assumed to be used at these
+interfaces. Additionally, extensions to RESTCONF, as defined in
+{{!RFC8527}}, to comply with the Network Management Datastore
+Architecture (NMDA) from {{!RFC8342}}, are assumed to be used at
 these MPI and MDSC NBI interfaces.
 
 {: #yang}
 
 ## YANG Data Models at the MPIs
 
-The data models used on these interfaces are assumed to use the YANG 
+The data models used on these interfaces are assumed to use the YANG
 1.1 Data Modeling Language, as defined in {{!RFC7950}}.
 
-This section describes the YANG data models applicable to the Packet 
-and Optical MPIs. Some of these YANG data models may be optional, 
-depending on the specific network configuration detailed in 
+This section describes the YANG data models applicable to the Packet
+and Optical MPIs. Some of these YANG data models may be optional,
+depending on the specific network configuration detailed in
 {{discovery}} and {{config}}.
 
 {: #common-yang}
 
 ### Common YANG Data Models at the MPIs
 
-As required in {{!RFC8040}}, the "ietf-yang-library" YANG module 
-defined in {{!RFC8525}} is used to allow the MDSC to discover the 
+As required in {{!RFC8040}}, the "ietf-yang-library" YANG module
+defined in {{!RFC8525}} is used to allow the MDSC to discover the
 set of YANG modules supported by each PNC at its MPI.
 
-Both Optical and Packet PNCs can use the following common topology 
+Both Optical and Packet PNCs can use the following common topology
 YANG data models at the MPI:
 
 - The Base Network Model, defined in the "ietf-network" YANG module
@@ -859,19 +855,19 @@ YANG module of {{!RFC8345}}, which augments the Base Network Model;
 module of {{!RFC8795}}, which augments the Base Network Topology
 Model.
 
-Optical and Packet PNCs can use the common TE Tunnel Model, defined 
+Optical and Packet PNCs can use the common TE Tunnel Model, defined
 in the "ietf-te" YANG module of {{!I-D.ietf-teas-yang-te}}, at the MPI.
 
-All common YANG data models are generic and augmented by 
-technology-specific YANG modules, as described in the following 
+All common YANG data models are generic and augmented by
+technology-specific YANG modules, as described in the following
 sections.
 
-Both Optical and Packet PNCs can also use the Ethernet Topology 
-Model, defined in the "ietf-eth-te-topology" YANG module of 
-{{!I-D.ietf-ccamp-eth-client-te-topo-yang}}, which augments the TE 
+Both Optical and Packet PNCs can also use the Ethernet Topology
+Model, defined in the "ietf-eth-te-topology" YANG module of
+{{!I-D.ietf-ccamp-eth-client-te-topo-yang}}, which augments the TE
 Topology Model with Ethernet technology-specific information.
 
-Both Optical and Packet PNCs can use the following common 
+Both Optical and Packet PNCs can use the following common
 notifications YANG data models at the MPI:
 
 - Dynamic Subscription to YANG Events and Datastores over RESTCONF
@@ -887,7 +883,7 @@ PNCs and MDSCs comply with subscription requirements as stated in
 
 ### YANG models at the Optical MPIs
 
-The Optical PNC can use the following technology-specific topology 
+The Optical PNC can use the following technology-specific topology
 YANG data models, which augment the generic TE Topology Model:
 
 - The WSON Topology Model, defined in the "ietf-wson-topology" YANG
@@ -913,8 +909,8 @@ The optical PNC can use the generic Path Computation YANG RPC,
 defined in the "ietf-te-path-computation" YANG module of
 {{!I-D.ietf-teas-yang-path-computation}}.
 
-Note that technology-specific augmentations of the generic path 
-computation RPC for WSON, Flexi-grid, and OTN path computation RPCs 
+Note that technology-specific augmentations of the generic path
+computation RPC for WSON, Flexi-grid, and OTN path computation RPCs
 have been identified as a gap.
 
 The optical PNC can use the following client signal YANG data models:
@@ -980,32 +976,32 @@ YANG module of {{?I-D.ietf-teas-te-service-mapping-yang}}.
 
 ## Path Computation Element Protocol (PCEP)
 
-{{?RFC8637}} examines the applicability of a Path Computation Element 
-(PCE) {{?RFC5440}} and PCE Communication Protocol (PCEP) to the ACTN 
-framework. It further describes how the PCE architecture applies to 
-ACTN and lists the PCEP extensions needed to use PCEP as an ACTN 
-interface. The stateful PCE {{?RFC8231}}, PCE-Initiation {{?RFC8281}}, 
-stateful Hierarchical PCE (H-PCE) {{?RFC8751}}, and PCE as a central 
-controller (PCECC) {{?RFC8283}} are key extensions enabling the use of 
+{{?RFC8637}} examines the applicability of a Path Computation Element
+(PCE) {{?RFC5440}} and PCE Communication Protocol (PCEP) to the ACTN
+framework. It further describes how the PCE architecture applies to
+ACTN and lists the PCEP extensions needed to use PCEP as an ACTN
+interface. The stateful PCE {{?RFC8231}}, PCE-Initiation {{?RFC8281}},
+stateful Hierarchical PCE (H-PCE) {{?RFC8751}}, and PCE as a central
+controller (PCECC) {{?RFC8283}} are key extensions enabling the use of
 PCE/PCEP for ACTN.
 
-Since PCEP supports path computation in both packet and optical 
-networks, it is well-suited for inter-layer path computation. 
-{{?RFC5623}} describes a framework for applying the PCE-based 
-architecture to interlayer (G)MPLS traffic engineering. Furthermore, 
-section 6.1 of {{?RFC8751}} outlines H-PCE applicability for 
+Since PCEP supports path computation in both packet and optical
+networks, it is well-suited for inter-layer path computation.
+{{?RFC5623}} describes a framework for applying the PCE-based
+architecture to interlayer (G)MPLS traffic engineering. Furthermore,
+section 6.1 of {{?RFC8751}} outlines H-PCE applicability for
 inter-layer or POI.
 
 {{?RFC8637}} lists various PCEP extensions that apply to ACTN. It also
 lists the PCEP extension for the optical network and POI.
 
-Note that PCEP can be used in conjunction with the YANG data models 
-described in the rest of this document. Depending on whether ACTN is 
+Note that PCEP can be used in conjunction with the YANG data models
+described in the rest of this document. Depending on whether ACTN is
 deployed in a greenfield or brownfield, two options are possible:
 
-1. The MDSC uses a single RESTCONF/YANG interface to each PNC to 
-discover all TE information and request TE tunnels. It may perform 
-full multi-layer path computation or delegate path computation to 
+1. The MDSC uses a single RESTCONF/YANG interface to each PNC to
+discover all TE information and request TE tunnels. It may perform
+full multi-layer path computation or delegate path computation to
 the underlying PNCs.
 
    This approach is desirable for operators from a multi-vendor
@@ -1054,7 +1050,7 @@ inventory information of their equipment used by the different
 management layers. In the context of POI, the inventory information
 of IP and optical equipment can complement the topology views and
 facilitate the packet/optical multi-layer view, e.g., by providing a
-mapping between the lowest level link termination points (LTPs) in 
+mapping between the lowest level link termination points (LTPs) in
 the topology view and corresponding ports in the network inventory view.
 
 The MDSC could also discover the entire network inventory information
@@ -1086,7 +1082,7 @@ In particular, for the cross-technology Ethernet links, it is key for
 MDSC to
 automatically correlate the information from the PNC network
 databases about the physical ports from the routers (single link or
-bundle links for Link Aggregation Group (LAG)) to client ports in the 
+bundle links for Link Aggregation Group (LAG)) to client ports in the
 ROADM.
 
 The analysis of multi-layer fault management is outside the scope of
@@ -1283,8 +1279,8 @@ Ethernet links or access links, as described in detail in
 and in {{multi-technology-link-discovery}}.
 
 All the intra-domain Ethernet and IP links are discovered by the
-P-PNCs, using mechanisms, such as Link Layer Discover Protocol LLDP 
-{{IEEE_802.1AB}}, which are outside the scope of this document, and 
+P-PNCs, using mechanisms, such as Link Layer Discover Protocol LLDP
+{{IEEE_802.1AB}}, which are outside the scope of this document, and
 reported at the MPIs within the Ethernet or the packet network topology.
 
 {: #te-path-discovery}
@@ -1378,66 +1374,65 @@ inter-domain links:
 
 2. LLDP {{IEEE_802.1AB}} automatic discovery
 
-Other link discovery options are possible but not described in this 
+Other link discovery options are possible but not described in this
 document.
 
-As outlined in {{?I-D.ietf-ccamp-transport-nbi-app-statement}}, the 
-encoding of the plug-id namespace and the specific LLDP information 
-reported within the plug-id value, such as the Chassis ID and Port ID 
-mandatory TLVs, is implementation-specific and needs to be consistent 
+As outlined in {{?I-D.ietf-ccamp-transport-nbi-app-statement}}, the
+encoding of the plug-id namespace and the specific LLDP information
+reported within the plug-id value, such as the Chassis ID and Port ID
+mandatory TLVs, is implementation-specific and needs to be consistent
 across all PNCs within the network.
 
-The static configuration requires an administrative burden to 
-configure network-wide unique identifiers, making it more viable for 
-inter-domain Ethernet links. For cross-technology Ethernet links, the 
-automatic discovery solution based on LLDP snooping is preferable when 
+The static configuration requires an administrative burden to
+configure network-wide unique identifiers, making it more viable for
+inter-domain Ethernet links. For cross-technology Ethernet links, the
+automatic discovery solution based on LLDP snooping is preferable when
 possible.
 
-The routers exchange standard LLDP packets as defined in {{IEEE_802.1AB}}, 
-and the optical nodes snoop the LLDP packets received from the local 
-Ethernet interface and report the extracted information, such as the 
+The routers exchange standard LLDP packets as defined in {{IEEE_802.1AB}},
+and the optical nodes snoop the LLDP packets received from the local
+Ethernet interface and report the extracted information, such as the
 Chassis ID, Port ID, and System Name TLVs, to the O-PNCs.
 
-Note that the optical nodes do not actively participate in the LLDP 
+Note that the optical nodes do not actively participate in the LLDP
 packet exchange and do not send any LLDP packets.
 
-### Cross-technology Ethernet link Discovery
-{#cross-technology-link-discovery}
+### Cross-technology Ethernet link Discovery {#cross-technology-link-discovery}
 
-The MDSC can discover a cross-technology Ethernet link by matching 
-the plug-id values of the two LTPs reported by adjacent O-PNC and 
-P-PNCs. In case LLDP snooping is used, the P-PNC reports the LLDP 
-information sent by the corresponding Ethernet interface on the IP 
-router, while the O-PNC reports the LLDP information received by the 
-corresponding Ethernet interface on the optical node, e.g., between 
-LTP 5-0 on PE13 and LTP 7-0 on NE11, as shown in 
+The MDSC can discover a cross-technology Ethernet link by matching
+the plug-id values of the two LTPs reported by adjacent O-PNC and
+P-PNCs. In case LLDP snooping is used, the P-PNC reports the LLDP
+information sent by the corresponding Ethernet interface on the IP
+router, while the O-PNC reports the LLDP information received by the
+corresponding Ethernet interface on the optical node, e.g., between
+LTP 5-0 on PE13 and LTP 7-0 on NE11, as shown in
 {{fig-cross-technology-link}}.
 
 {::include ./figures/cross-technology-link.md}
 {: #fig-cross-technology-link title="Cross-technology Ethernet link
 discovery"}
 
-As described in {{optical-topology-discovery}}, the LTP terminating 
-a cross-technology Ethernet link is reported by an O-PNC in the 
-Ethernet topology, the OTN topology model, or both, depending on the 
+As described in {{optical-topology-discovery}}, the LTP terminating
+a cross-technology Ethernet link is reported by an O-PNC in the
+Ethernet topology, the OTN topology model, or both, depending on the
 type of corresponding physical port on the optical node.
 
-It is worth noting that the discovery of cross-technology Ethernet 
-links is based solely on the LLDP information sent by the Ethernet 
-interfaces of the routers and snooped by the Ethernet interfaces of 
-the optical nodes. Therefore, the MDSC can discover these links even 
-before optical paths, supporting overlay multi-technology IP links, 
+It is worth noting that the discovery of cross-technology Ethernet
+links is based solely on the LLDP information sent by the Ethernet
+interfaces of the routers and snooped by the Ethernet interfaces of
+the optical nodes. Therefore, the MDSC can discover these links even
+before optical paths, supporting overlay multi-technology IP links,
 are set up.
 
 {: #ip-inter-domain-link-discovery}
 
 ### Inter-domain IP Link Discovery
 
-The MDSC can discover an inter-domain Ethernet link supporting an 
-inter-domain IP link by matching the plug-id values of the two 
-Ethernet LTPs reported by adjacent P-PNCs. The P-PNCs report the 
-LLDP information being sent and received from the corresponding 
-Ethernet interfaces, e.g., between Ethernet LTP 3-1 on BR11 and 
+The MDSC can discover an inter-domain Ethernet link supporting an
+inter-domain IP link by matching the plug-id values of the two
+Ethernet LTPs reported by adjacent P-PNCs. The P-PNCs report the
+LLDP information being sent and received from the corresponding
+Ethernet interfaces, e.g., between Ethernet LTP 3-1 on BR11 and
 Ethernet LTP 4-1 on BR21, as shown in {{fig-inter-domain-link}}.
 
 {::include ./figures/inter-domain-link.md}
@@ -1449,60 +1444,60 @@ the plug-id attribute of the Ethernet LTPs to discover cross-technology
 Ethernet
 links and inter-domain Ethernet links.
 
-If the P-PNC does not know a priori whether an Ethernet interface 
-on an IP router terminates a cross-technology Ethernet link or an 
-inter-domain Ethernet link, it must report at the MPI two Ethernet 
-LTPs representing the same Ethernet interface, e.g., both Ethernet 
-LTP 3-0 and Ethernet LTP 3-1, supported by LTP 3-0, as shown in 
+If the P-PNC does not know a priori whether an Ethernet interface
+on an IP router terminates a cross-technology Ethernet link or an
+inter-domain Ethernet link, it must report at the MPI two Ethernet
+LTPs representing the same Ethernet interface, e.g., both Ethernet
+LTP 3-0 and Ethernet LTP 3-1, supported by LTP 3-0, as shown in
 {{fig-inter-domain-link}}.
 
-- The physical Ethernet LTP (e.g., LTP 3-0 in BR11, as shown in 
-{{fig-inter-domain-link}}) represents the physical adjacency between 
-the Ethernet interface on an IP router and the Ethernet interface on 
-its physically adjacent node. This node can be either an IP router 
-(in the case of a single-technology Ethernet link) or an optical node 
-(in the case of a cross-technology Ethernet link). Therefore, as 
-described in {{cross-technology-link-discovery}}, the P-PNC reports, 
-within the plug-id attribute of this LTP, the LLDP information sent 
-by the corresponding Ethernet interface on the IP router, such as 
-{BR11,3} and {BR21,4} plug-id values reported by the Ethernet LTP 
-3-0 on BR11 and the Ethernet LTP 4-0 on BR21, as shown in 
+- The physical Ethernet LTP (e.g., LTP 3-0 in BR11, as shown in
+{{fig-inter-domain-link}}) represents the physical adjacency between
+the Ethernet interface on an IP router and the Ethernet interface on
+its physically adjacent node. This node can be either an IP router
+(in the case of a single-technology Ethernet link) or an optical node
+(in the case of a cross-technology Ethernet link). Therefore, as
+described in {{cross-technology-link-discovery}}, the P-PNC reports,
+within the plug-id attribute of this LTP, the LLDP information sent
+by the corresponding Ethernet interface on the IP router, such as
+{BR11,3} and {BR21,4} plug-id values reported by the Ethernet LTP
+3-0 on BR11 and the Ethernet LTP 4-0 on BR21, as shown in
 {{fig-inter-domain-link}}.
 
-- The logical Ethernet LTP (e.g., LTP 3-1 in BR11, as shown in 
-{{fig-inter-domain-link}}), supported by a physical Ethernet LTP (e.g., 
-LTP 3-0 in BR11, as shown in {{fig-inter-domain-link}}), is used to 
-discover the logical adjacency between Ethernet interfaces on IP routers, 
-which can be either single-technology or multi-technology. Therefore, 
-the P-PNC reports, within the plug-id attribute of this LTP, the LLDP 
-information sent and received by the corresponding Ethernet interface 
-on the IP router, such as the {BR11,3,BR21,4} plug-id values reported 
-by the Ethernet LTP 3-1 on BR11 and the Ethernet LTP 4-1 on BR21, as 
+- The logical Ethernet LTP (e.g., LTP 3-1 in BR11, as shown in
+{{fig-inter-domain-link}}), supported by a physical Ethernet LTP (e.g.,
+LTP 3-0 in BR11, as shown in {{fig-inter-domain-link}}), is used to
+discover the logical adjacency between Ethernet interfaces on IP routers,
+which can be either single-technology or multi-technology. Therefore,
+the P-PNC reports, within the plug-id attribute of this LTP, the LLDP
+information sent and received by the corresponding Ethernet interface
+on the IP router, such as the {BR11,3,BR21,4} plug-id values reported
+by the Ethernet LTP 3-1 on BR11 and the Ethernet LTP 4-1 on BR21, as
 shown in {{fig-inter-domain-link}}.
 
-It is worth noting that in the case of inter-domain Ethernet links, 
-the MDSC cannot discover, using the LLDP information reported in the 
-plug-id attributes, the physical adjacency between two Ethernet 
-interfaces on physically adjacent IP routers, because these plug-id 
-values do not match, such as the {BR11,3} and {BR21,4} plug-id values 
-shown in {{fig-inter-domain-link}}. However, the MDSC may infer the 
-physical intra-domain Ethernet links if it knows a priori, using 
-mechanisms outside the scope of this document, that the Ethernet 
-interfaces on the IP routers either terminate a cross-technology or 
-single-technology (intra-domain or inter-domain) Ethernet link, e.g., 
+It is worth noting that in the case of inter-domain Ethernet links,
+the MDSC cannot discover, using the LLDP information reported in the
+plug-id attributes, the physical adjacency between two Ethernet
+interfaces on physically adjacent IP routers, because these plug-id
+values do not match, such as the {BR11,3} and {BR21,4} plug-id values
+shown in {{fig-inter-domain-link}}. However, the MDSC may infer the
+physical intra-domain Ethernet links if it knows a priori, using
+mechanisms outside the scope of this document, that the Ethernet
+interfaces on the IP routers either terminate a cross-technology or
+single-technology (intra-domain or inter-domain) Ethernet link, e.g.,
 as shown in {{fig-inter-domain-link}}.
 
-The P-PNC can omit reporting the physical Ethernet LTPs when it 
-knows, through mechanisms outside the scope of this document, that 
-the corresponding Ethernet interfaces terminate inter-domain Ethernet 
+The P-PNC can omit reporting the physical Ethernet LTPs when it
+knows, through mechanisms outside the scope of this document, that
+the corresponding Ethernet interfaces terminate inter-domain Ethernet
 links.
 
-The MDSC can then discover an inter-domain IP link between the two IP 
-LTPs supported by the two Ethernet LTPs terminating an inter-domain 
+The MDSC can then discover an inter-domain IP link between the two IP
+LTPs supported by the two Ethernet LTPs terminating an inter-domain
 Ethernet link, discovered as described in
-{{ip-inter-domain-link-discovery}}, 
-e.g., between IP LTP 3-2 on BR21 and IP LTP 4-2 on BR22, supported 
-respectively by Ethernet LTP 3-1 on BR11 and Ethernet LTP 4-1 on BR21, 
+{{ip-inter-domain-link-discovery}},
+e.g., between IP LTP 3-2 on BR21 and IP LTP 4-2 on BR22, supported
+respectively by Ethernet LTP 3-1 on BR11 and Ethernet LTP 4-1 on BR21,
 as shown in {{fig-inter-domain-link}}.
 
 {: #multi-technology-link-discovery}
@@ -1572,34 +1567,34 @@ on PE13, shown in {{fig-intra-domain-link}}.
 {: #fig-intra-domain-link title="Single-technology intra-domain Ethernet
 and IP link discovery"}
 
-It is worth noting that in the case of intra-domain single-technology 
-Ethernet links, the MDSC cannot discover, using the LLDP information 
-reported in the plug-id attributes, the physical adjacency between 
-two Ethernet interfaces on physically adjacent IP routers, because 
-the plug-id values do not match, such as {PE13,1} and {P16,2}, as shown 
-in {{fig-intra-domain-link}}. However, the MDSC may infer the physical 
-intra-domain Ethernet links, e.g., between LTP 1-0 on PE13 and LTP 2-0 
-on P16, as shown in {{fig-intra-domain-link}}, if it knows a priori, 
-using mechanisms outside the scope of this document, that all Ethernet 
-interfaces on the IP routers terminate either a cross-technology or 
-single-technology (intra-domain or inter-domain) Ethernet link, e.g., 
+It is worth noting that in the case of intra-domain single-technology
+Ethernet links, the MDSC cannot discover, using the LLDP information
+reported in the plug-id attributes, the physical adjacency between
+two Ethernet interfaces on physically adjacent IP routers, because
+the plug-id values do not match, such as {PE13,1} and {P16,2}, as shown
+in {{fig-intra-domain-link}}. However, the MDSC may infer the physical
+intra-domain Ethernet links, e.g., between LTP 1-0 on PE13 and LTP 2-0
+on P16, as shown in {{fig-intra-domain-link}}, if it knows a priori,
+using mechanisms outside the scope of this document, that all Ethernet
+interfaces on the IP routers terminate either a cross-technology or
+single-technology (intra-domain or inter-domain) Ethernet link, e.g.,
 as shown in {{fig-intra-domain-link}}.
 
-The P-PNC can omit reporting the physical Ethernet LTP if it knows, 
-through mechanisms outside the scope of this document, that the 
+The P-PNC can omit reporting the physical Ethernet LTP if it knows,
+through mechanisms outside the scope of this document, that the
 intra-domain Ethernet link is single-technology.
 
 {: #lag-discovery}
 
 ## LAG Discovery
 
-The P-PNCs can discover the configuration of LAG groups within its 
-domain and report each intra-domain LAG as an Ethernet bundle link 
+The P-PNCs can discover the configuration of LAG groups within its
+domain and report each intra-domain LAG as an Ethernet bundle link
 within the Ethernet topology exposed at the MPI.
 
-This is done by bundling multiple single-domain Ethernet links, as 
-shown in {{fig-lag}}. For example, the Ethernet bundled link between 
-Ethernet LTP 5-1 on BR21 and Ethernet LTP 6-1 on P24 is built from 
+This is done by bundling multiple single-domain Ethernet links, as
+shown in {{fig-lag}}. For example, the Ethernet bundled link between
+Ethernet LTP 5-1 on BR21 and Ethernet LTP 6-1 on P24 is built from
 the Ethernet links set up respectively:
 
 - between the Ethernet LTP 1-1 on BR21 and the Ethernet LTP 2-1 on
@@ -1611,23 +1606,23 @@ P24.
 {::include ./figures/lag.md}
 {: #fig-lag title="LAG"}
 
-The mechanisms used by the MDSC to discover single-technology and 
-multi-technology intra-domain LAG links are the same, with the only 
-difference being whether the bundled links are single-technology or 
+The mechanisms used by the MDSC to discover single-technology and
+multi-technology intra-domain LAG links are the same, with the only
+difference being whether the bundled links are single-technology or
 multi-technology.
 
-However, the mechanisms used by the MDSC to discover single-technology 
-inter-domain LAG links between two BRs are different and outside the 
+However, the mechanisms used by the MDSC to discover single-technology
+inter-domain LAG links between two BRs are different and outside the
 scope of this document, as they do not imply cross-technology
-coordination 
+coordination
 between packet and optical domains.
 
-As described in {{packet-topology-discovery}}, the mechanisms used by the 
-P-PNC to discover the configuration of LAG groups within its domain, such 
+As described in {{packet-topology-discovery}}, the mechanisms used by the
+P-PNC to discover the configuration of LAG groups within its domain, such
 as LLDP {{IEEE_802.1AB}}, are outside the scope of this document.
 
-It is worth noting that according to {{IEEE_802.1AB}}, LLDP can be 
-configured on a LAG group (Aggregated Port) and/or on any number of its 
+It is worth noting that according to {{IEEE_802.1AB}}, LLDP can be
+configured on a LAG group (Aggregated Port) and/or on any number of its
 LAG members (Aggregation Ports).
 
 If LLDP is enabled on both LAG members and groups, two types of LLDP
@@ -1739,10 +1734,10 @@ optical
    the L2/L3 VPN service or because there is no TE path between
    PE13 and PE23.
 
-As described in {{path-computation-overview}}, with partial 
-summarization, the MDSC will use the TE topology information provided 
-by the P-PNCs and the results of the path computation requests sent to 
-the O-PNCs, as described in {{optical-path-computation}}, to compute 
+As described in {{path-computation-overview}}, with partial
+summarization, the MDSC will use the TE topology information provided
+by the P-PNCs and the results of the path computation requests sent to
+the O-PNCs, as described in {{optical-path-computation}}, to compute
 the multi-layer/multi-domain path between PE13 and PE23.
 
 For example, the multi-layer/multi-domain performed by the MDSC could
@@ -1755,9 +1750,9 @@ new IP link, as described in {{multi-technology-link-setup}};
 bandwidth of the IP link(s) between BR21 and P24, as described in
 {{multi-technology-link-setup}}.
 
-When setting up the L2/L3 VPN network service requires multi-domain 
-and multi-layer coordination, the MDSC is also responsible for 
-coordinating the network configuration needed to realize the requested 
+When setting up the L2/L3 VPN network service requires multi-domain
+and multi-layer coordination, the MDSC is also responsible for
+coordinating the network configuration needed to realize the requested
 network service across the appropriate optical and packet domains.
 
 The MDSC would therefore request:
@@ -1774,56 +1769,56 @@ PE13 and P16, as described in {{multi-technology-link-setup}};
 - the P-PNC1 to update the bandwidth of the selected TE path between
 PE13 and PE14, as described in {{te-path-config}}.
 
-After that, the MDSC requests P-PNC2 to set up a TE path between BR21 
-and PE23, with an explicit path (BR21, P24, PE23) to constrain the 
-new TE path to use the underlay optical tunnel setup between BR21 and 
-P24, as described in {{te-path-config}}. The P-PNC2 properly configures 
-the routers within its domain to set up the requested path and returns 
-the information needed for multi-domain TE path stitching. For example, 
-in inter-domain SR-TE, the P-PNC2, knowing the node and adjacency SIDs 
-assigned within its domain, can install the proper SR policy or 
-hierarchical policies within BR21 and return to the MDSC the binding 
+After that, the MDSC requests P-PNC2 to set up a TE path between BR21
+and PE23, with an explicit path (BR21, P24, PE23) to constrain the
+new TE path to use the underlay optical tunnel setup between BR21 and
+P24, as described in {{te-path-config}}. The P-PNC2 properly configures
+the routers within its domain to set up the requested path and returns
+the information needed for multi-domain TE path stitching. For example,
+in inter-domain SR-TE, the P-PNC2, knowing the node and adjacency SIDs
+assigned within its domain, can install the proper SR policy or
+hierarchical policies within BR21 and return to the MDSC the binding
 SID assigned to this policy in BR21.
 
-Then the MDSC requests P-PNC1 to set up a TE path between PE13 and 
-BR11, with an explicit path (PE13, BR11) to constrain the new TE path 
-to use the underlay optical tunnel setup between PE13 and BR11, 
-specifying which inter-domain link should be used to send traffic to 
-BR21 and the information for multi-domain TE path stitching, as 
-described in {{te-path-discovery}} (e.g., in inter-domain SR-TE, the 
-binding SID assigned by P-PNC2 to the corresponding SR policy in BR21). 
-The P-PNC1 properly configures the routers within its domain to set up 
-the requested path and the multi-domain TE path stitching. For example, 
-in inter-domain SR-TE, the P-PNC1, knowing the node and adjacency SIDs 
-assigned within its domain and the PE SID assigned by P-PNC1 to the 
-inter-domain link between BR11 and BR21, along with the binding SID 
+Then the MDSC requests P-PNC1 to set up a TE path between PE13 and
+BR11, with an explicit path (PE13, BR11) to constrain the new TE path
+to use the underlay optical tunnel setup between PE13 and BR11,
+specifying which inter-domain link should be used to send traffic to
+BR21 and the information for multi-domain TE path stitching, as
+described in {{te-path-discovery}} (e.g., in inter-domain SR-TE, the
+binding SID assigned by P-PNC2 to the corresponding SR policy in BR21).
+The P-PNC1 properly configures the routers within its domain to set up
+the requested path and the multi-domain TE path stitching. For example,
+in inter-domain SR-TE, the P-PNC1, knowing the node and adjacency SIDs
+assigned within its domain and the PE SID assigned by P-PNC1 to the
+inter-domain link between BR11 and BR21, along with the binding SID
 assigned by P-PNC2, installs the proper policy or policies within PE13.
 
-Once the TE paths have been selected and, if needed, set up or modified, 
-the MDSC can request both P-PNCs to configure the L3VPN and its binding 
+Once the TE paths have been selected and, if needed, set up or modified,
+the MDSC can request both P-PNCs to configure the L3VPN and its binding
 with the selected TE paths, as described in {{vpn-setup}}.
 
 {: #optical-path-computation}
 
 ## Optical Path Computation
 
-As described in {{path-computation-overview}}, optical path 
+As described in {{path-computation-overview}}, optical path
 computation is usually performed by the O-PNCs.
 
-When performing multi-layer/multi-domain path computation, the MDSC 
+When performing multi-layer/multi-domain path computation, the MDSC
 can delegate single-domain optical path computation to the O-PNC.
 
-As described in {{optical-topology-discovery}}, {{inter-domain-link-discovery}}, 
-and {{multi-technology-link-discovery}}, there is a one-to-one 
-relationship between a multi-layer intra-domain IP link and its underlay 
-optical tunnel. Therefore, the properties of an optical path between 
-two optical TTPs, as computed by the O-PNC, can be used by the MDSC to 
+As described in {{optical-topology-discovery}}, {{inter-domain-link-discovery}},
+and {{multi-technology-link-discovery}}, there is a one-to-one
+relationship between a multi-layer intra-domain IP link and its underlay
+optical tunnel. Therefore, the properties of an optical path between
+two optical TTPs, as computed by the O-PNC, can be used by the MDSC to
 infer the properties of the associated multi-layer single-domain IP link.
 
-As discussed in {{!I-D.ietf-teas-yang-path-computation}}, there are two 
-options to request an O-PNC to perform optical path computation: either 
-via a "compute-only" TE tunnel path, using the generic TE tunnel YANG 
-data model defined in {{!I-D.ietf-teas-yang-te}}, or via the path 
+As discussed in {{!I-D.ietf-teas-yang-path-computation}}, there are two
+options to request an O-PNC to perform optical path computation: either
+via a "compute-only" TE tunnel path, using the generic TE tunnel YANG
+data model defined in {{!I-D.ietf-teas-yang-te}}, or via the path
 computation RPC defined in {{!I-D.ietf-teas-yang-path-computation}}.
 
 This draft assumes that the path computation RPC is used.
@@ -1839,61 +1834,61 @@ scope.
 
 ## Multi-technology IP Link Setup
 
-As described in {{optical-path-computation}}, there is a one-to-one 
-relationship between a multi-technology intra-domain IP link and its 
+As described in {{optical-path-computation}}, there is a one-to-one
+relationship between a multi-technology intra-domain IP link and its
 underlay optical tunnel.
 
-Therefore, to set up a new multi-technology intra-domain IP link, 
-the MDSC requires the O-PNC to set up the optical tunnel (using either 
-the DWDM Tunnel model or the OTN Tunnel model, if optional OTN switching 
-is supported) within the optical network and steer client traffic 
-between the two cross-technology Ethernet links over that optical tunnel, 
-using either the Ethernet Client Signal Model (for frame-based transport) 
+Therefore, to set up a new multi-technology intra-domain IP link,
+the MDSC requires the O-PNC to set up the optical tunnel (using either
+the DWDM Tunnel model or the OTN Tunnel model, if optional OTN switching
+is supported) within the optical network and steer client traffic
+between the two cross-technology Ethernet links over that optical tunnel,
+using either the Ethernet Client Signal Model (for frame-based transport)
 or the Transparent CBR Client Signal Model (for transparent transport).
 
-For example, with reference to {{fig-multi-technology-link-2}}, the 
-MDSC can request O-PNC1 to set up an optical tunnel between optical 
-TTPs (7) on NE11 and (8) on NE12 and steer client traffic over this 
+For example, with reference to {{fig-multi-technology-link-2}}, the
+MDSC can request O-PNC1 to set up an optical tunnel between optical
+TTPs (7) on NE11 and (8) on NE12 and steer client traffic over this
 tunnel between LTP (7-0) on NE11 and LTP (8-0) on NE12.
 
 {::include ./figures/multi-technology-intra-domain-link.md}
 {: #fig-multi-technology-link-2 title="Multi-technology IP link setup"}
 
-Note: {{fig-multi-technology-link-2}} is an exact copy of 
+Note: {{fig-multi-technology-link-2}} is an exact copy of
 {{fig-multi-technology-link}}.
 
-After the optical tunnel has been set up and the client traffic 
-steering configured, the two IP routers can exchange Ethernet frames 
+After the optical tunnel has been set up and the client traffic
+steering configured, the two IP routers can exchange Ethernet frames
 between themselves, including LLDP messages.
 
-If LLDP {{IEEE_802.1AB}} or any other discovery mechanisms, outside 
-the scope of this document, are used between the adjacency of the two 
-IP routers' ports, the P-PNC can automatically discover the underlay 
-multi-technology single-domain Ethernet link set up by the MDSC and 
+If LLDP {{IEEE_802.1AB}} or any other discovery mechanisms, outside
+the scope of this document, are used between the adjacency of the two
+IP routers' ports, the P-PNC can automatically discover the underlay
+multi-technology single-domain Ethernet link set up by the MDSC and
 report it to the P-PNC, as described in {{multi-technology-link-discovery}}.
 
-Otherwise, if no automatic discovery mechanisms are used, the MDSC 
-can configure this multi-technology single-domain Ethernet link at 
+Otherwise, if no automatic discovery mechanisms are used, the MDSC
+can configure this multi-technology single-domain Ethernet link at
 the MPI of the P-PNC.
 
-The two Ethernet LTPs terminating this multi-technology single-domain 
-Ethernet link are supported by the two underlay Ethernet LTPs 
-terminating the two cross-technology Ethernet links, e.g., LTP 5-1 on 
+The two Ethernet LTPs terminating this multi-technology single-domain
+Ethernet link are supported by the two underlay Ethernet LTPs
+terminating the two cross-technology Ethernet links, e.g., LTP 5-1 on
 PE13 and 6-1 on BR11, as shown in {{fig-multi-technology-link-2}}.
 
-After the multi-technology single-domain Ethernet link has been 
-configured by the MDSC or discovered by the P-PNC, the corresponding 
-multi-technology single-domain IP link can also be configured either 
+After the multi-technology single-domain Ethernet link has been
+configured by the MDSC or discovered by the P-PNC, the corresponding
+multi-technology single-domain IP link can also be configured either
 by the MDSC or the P-PNC.
 
 This document assumes that the IP link is configured by the P-PNC.
 
-It is worth noting that if LAG is not supported within the domain 
-controlled by the P-PNC, the P-PNC can configure the multi-technology 
-single-domain IP link as soon as the underlay multi-technology 
-single-domain Ethernet link is either discovered by the P-PNC or 
-configured by the MDSC at the MPI. However, if LAG is supported, the 
-P-PNC lacks enough information to determine whether the discovered or 
+It is worth noting that if LAG is not supported within the domain
+controlled by the P-PNC, the P-PNC can configure the multi-technology
+single-domain IP link as soon as the underlay multi-technology
+single-domain Ethernet link is either discovered by the P-PNC or
+configured by the MDSC at the MPI. However, if LAG is supported, the
+P-PNC lacks enough information to determine whether the discovered or
 configured multi-technology single-domain Ethernet link would be:
 
 1. Used to support a multi-technology single-domain IP link;
@@ -1902,59 +1897,59 @@ configured multi-technology single-domain Ethernet link would be:
 
 3. Added to an existing LAG group.
 
-The MDSC can request the P-PNC to configure a new multi-technology 
-single-domain IP link, supported by the just discovered or configured 
-multi-technology single-domain Ethernet link, by creating an IP link 
-within the running datastore of the P-PNC MPI. Only the IP link, IP 
-LTPs, and the reference to the supporting multi-technology single-domain 
-Ethernet link are configured by the MDSC. All other configuration is 
+The MDSC can request the P-PNC to configure a new multi-technology
+single-domain IP link, supported by the just discovered or configured
+multi-technology single-domain Ethernet link, by creating an IP link
+within the running datastore of the P-PNC MPI. Only the IP link, IP
+LTPs, and the reference to the supporting multi-technology single-domain
+Ethernet link are configured by the MDSC. All other configuration is
 provided by the P-PNC.
 
-For example, with reference to {{fig-multi-technology-link-2}}, the 
-MDSC can request P-PNC1 to set up a multi-technology single-domain 
-IP link between IP LTP 5-2 on PE13 and IP LTP 6-2 on BR11, supported 
-by the multi-technology single-domain Ethernet link between ETH LTP 
+For example, with reference to {{fig-multi-technology-link-2}}, the
+MDSC can request P-PNC1 to set up a multi-technology single-domain
+IP link between IP LTP 5-2 on PE13 and IP LTP 6-2 on BR11, supported
+by the multi-technology single-domain Ethernet link between ETH LTP
 5-1 on PE13 and ETH LTP 6-1 on BR11.
 
-The P-PNC configures the requested multi-technology single-domain 
-IP link and, once finished, reports it to the MDSC within the IP 
+The P-PNC configures the requested multi-technology single-domain
+IP link and, once finished, reports it to the MDSC within the IP
 topology exposed at its MPI.
 
 {: #lag-setup}
 
 ### Multi-technology LAG Setup
 
-The P-PNC configures a new LAG group between two routers when the 
-MDSC creates a new Ethernet bundled link at the MPI (using the 
-bundled-link container defined in {{!RFC8795}}), bundling the 
-multi-technology single-domain Ethernet link(s) being created, as 
+The P-PNC configures a new LAG group between two routers when the
+MDSC creates a new Ethernet bundled link at the MPI (using the
+bundled-link container defined in {{!RFC8795}}), bundling the
+multi-technology single-domain Ethernet link(s) being created, as
 described above.
 
-When a new LAG link is created, it is recommended to configure the 
-minimum number of active member links required to consider the LAG 
-link as up. For example, a LAG link with three members can be 
-considered up when only one member link fails and down when at least 
+When a new LAG link is created, it is recommended to configure the
+minimum number of active member links required to consider the LAG
+link as up. For example, a LAG link with three members can be
+considered up when only one member link fails and down when at least
 two member links fail.
 
-The attribute required to configure the minimum number of active 
-member links is missing in {{!I-D.ietf-ccamp-eth-client-te-topo-yang}} 
+The attribute required to configure the minimum number of active
+member links is missing in {{!I-D.ietf-ccamp-eth-client-te-topo-yang}}
 and is identified as a gap in {{conclusions}}.
 
-It is worth noting that a new LAG group can be created to bundle one 
+It is worth noting that a new LAG group can be created to bundle one
 or more multi-technology single-domain Ethernet link(s).
 
-For example, with reference to {{fig-lag}}, the MDSC can request 
-P-PNC2 to set up an Ethernet bundled link between Ethernet LTP 5-1 on 
-BR21 and Ethernet LTP 6-1 on P24, bundling the multi-technology 
-single-domain Ethernet link between Ethernet LTP 1-1 on BR21 and 
+For example, with reference to {{fig-lag}}, the MDSC can request
+P-PNC2 to set up an Ethernet bundled link between Ethernet LTP 5-1 on
+BR21 and Ethernet LTP 6-1 on P24, bundling the multi-technology
+single-domain Ethernet link between Ethernet LTP 1-1 on BR21 and
 Ethernet LTP 2-1 on P24.
 
-It is also worth noting that the MDSC needs to create the Ethernet 
+It is also worth noting that the MDSC needs to create the Ethernet
 LTPs terminating the Ethernet bundled link.
 
-The MDSC can request the P-PNC to configure a new multi-technology 
-single-domain IP link, supported by the just configured Ethernet 
-bundled link, following the same procedure described in 
+The MDSC can request the P-PNC to configure a new multi-technology
+single-domain IP link, supported by the just configured Ethernet
+bundled link, following the same procedure described in
 {{multi-technology-link-setup}} above.
 
 For example, with a reference to {{fig-lag}}, the MDSC can request the
@@ -1964,23 +1959,23 @@ between ETH LTP 5-1 on BR21 and the Ethernet LTP 6-1 on P24.
 
 ### Multi-technology LAG Update
 
-The P-PNC adds new member(s) to an existing LAG group when the MDSC 
-updates the configuration of an existing Ethernet bundled link at the 
-MPI, adding the multi-technology single-domain Ethernet link(s) being 
+The P-PNC adds new member(s) to an existing LAG group when the MDSC
+updates the configuration of an existing Ethernet bundled link at the
+MPI, adding the multi-technology single-domain Ethernet link(s) being
 created, as described above.
 
-When member links are added or removed from a LAG link, the minimum 
-number of active member links required to consider the LAG link as up 
+When member links are added or removed from a LAG link, the minimum
+number of active member links required to consider the LAG link as up
 may also need to be updated.
 
-For example, with reference to {{fig-lag}}, the MDSC can request 
-P-PNC2 to add the multi-technology single-domain Ethernet link set up 
-between Ethernet LTP 3-1 on BR21 and Ethernet LTP 4-1 on P24 to the 
-existing Ethernet bundle link set up between Ethernet LTP 5-1 on node 
+For example, with reference to {{fig-lag}}, the MDSC can request
+P-PNC2 to add the multi-technology single-domain Ethernet link set up
+between Ethernet LTP 3-1 on BR21 and Ethernet LTP 4-1 on P24 to the
+existing Ethernet bundle link set up between Ethernet LTP 5-1 on node
 BR21 and Ethernet LTP 6-1 on node P24.
 
-After the LAG configuration has been updated, the P-PNC can also update 
-the bandwidth information of the multi-technology single-domain IP link 
+After the LAG configuration has been updated, the P-PNC can also update
+the bandwidth information of the multi-technology single-domain IP link
 supported by the updated Ethernet bundled link.
 
 {: #multi-technology-path-properties}
@@ -2027,11 +2022,11 @@ the MPI could be done using the generic TE tunnel YANG data model,
 defined in {{!I-D.ietf-teas-yang-te}}, with packet technology-specific
 augmentations, described in {{packet-yang}}.
 
-When a new TE path needs to be setup, the MDSC can use the 
-{{!I-D.ietf-teas-yang-te}} model to request the P-PNC to set it up, 
-properly specifying the path constraints, such as the explicit path, 
-to ensure the P-PNC sets up a TE path that meets the end-to-end TE 
-and binding constraints and uses the optical tunnels set up by the 
+When a new TE path needs to be setup, the MDSC can use the
+{{!I-D.ietf-teas-yang-te}} model to request the P-PNC to set it up,
+properly specifying the path constraints, such as the explicit path,
+to ensure the P-PNC sets up a TE path that meets the end-to-end TE
+and binding constraints and uses the optical tunnels set up by the
 MDSC to support this new TE path.
 
 The {{!I-D.ietf-teas-yang-te}} model supports requesting the setup of
@@ -2064,7 +2059,7 @@ further discuss whether to put this text here or in
 The MDSC also request the P-PNC to configure local protection mechanisms.
 For example, the FRR local protection, as defined in {{?RFC4090}} in case
 of MPLS-TE domain or the TI-LFA local protection, as defined in
-{{?I-D.ietf-rtgwg-segment-routing-ti-lfa}} in case of SR-TE domain. The 
+{{?I-D.ietf-rtgwg-segment-routing-ti-lfa}} in case of SR-TE domain. The
 mechanisms to request the configuration TI-LFA local protection for SR-TE
 paths using the {{!I-D.ietf-teas-yang-te}} are a gap in the current YANG
 models.
@@ -2089,36 +2084,36 @@ scope of this draft.
 
 ## L2/L3 VPN Network Service Setup
 
-The MDSC can use the L2NM and L3NM network service models to request 
-the P-PNCs to setup L2/L3 VPN services, and the L2NM and L3NM TE 
-service mapping models to request the P-PNCs to configure the PE 
-routers to steer the L2/L3 VPN traffic to the selected TE tunnels 
+The MDSC can use the L2NM and L3NM network service models to request
+the P-PNCs to setup L2/L3 VPN services, and the L2NM and L3NM TE
+service mapping models to request the P-PNCs to configure the PE
+routers to steer the L2/L3 VPN traffic to the selected TE tunnels
 (e.g., MPLS-TE or SR-TE).
 
-It is worth noting that the L2NM and L3NM TE service mapping models, 
-defined in {{?I-D.ietf-teas-te-service-mapping-yang}}, provide a list 
-of TE tunnel(s) that should be used to forward L2/L3 VPN traffic 
-between the two PEs terminating the listed TE tunnel(s). If the list 
-contains more than one TE tunnel for the same pair of PEs, these TE 
-tunnels are used to load balance the associated L2/L3 VPN traffic 
+It is worth noting that the L2NM and L3NM TE service mapping models,
+defined in {{?I-D.ietf-teas-te-service-mapping-yang}}, provide a list
+of TE tunnel(s) that should be used to forward L2/L3 VPN traffic
+between the two PEs terminating the listed TE tunnel(s). If the list
+contains more than one TE tunnel for the same pair of PEs, these TE
+tunnels are used to load balance the associated L2/L3 VPN traffic
 between the same set of two PEs.
 
-The possibility to request splitting the traffic between multiple TE 
-tunnels for the same PE pair in a way other than load balancing is 
-identified as a gap requiring further work and is outside the scope 
+The possibility to request splitting the traffic between multiple TE
+tunnels for the same PE pair in a way other than load balancing is
+identified as a gap requiring further work and is outside the scope
 of this draft.
 
 {: #conclusions}
 
 # Conclusions
 
-The analysis provided in this document shows that the IETF YANG models 
-described in 3.2 provide useful support for Packet Optical Integration 
-(POI) scenarios for resource discovery (network topology, service, 
-tunnels, and network inventory discovery), as well as for supporting 
+The analysis provided in this document shows that the IETF YANG models
+described in 3.2 provide useful support for Packet Optical Integration
+(POI) scenarios for resource discovery (network topology, service,
+tunnels, and network inventory discovery), as well as for supporting
 multi-layer/multi-domain L2/L3 VPN network services.
 
-The following gaps were identified that may need to be addressed by 
+The following gaps were identified that may need to be addressed by
 the relevant IETF Working Groups:
 
 - how both WSON and Flexi-grid topology models could be used
@@ -2162,20 +2157,20 @@ load balancing: this gap has been identified in {{vpn-setup}};
 - a mechanism to report client connectivity constraints imposed by
 some muxponder design: this gap has been identified in {{muxponder}}.
 
-Although not applicable to this document, it has been noted that being 
-able to use WSON and Flexi-grid topology models together (through 
-multi-inheritance) is not only useful for mixed fixed-grid and 
-flexible-grid DWDM network topologies but also the only viable option 
+Although not applicable to this document, it has been noted that being
+able to use WSON and Flexi-grid topology models together (through
+multi-inheritance) is not only useful for mixed fixed-grid and
+flexible-grid DWDM network topologies but also the only viable option
 for a mixed CWDM and DWDM network topology.
 
-Although not applicable to this document, it has been noted that the 
-DWDM tunnel model would also support optical tunnel setup in the case 
+Although not applicable to this document, it has been noted that the
+DWDM tunnel model would also support optical tunnel setup in the case
 of a mixed CWDM and DWDM network topology.
 
-Although not analyzed in this document, it has been noted that the TE 
-Tunnel model, defined in {{!I-D.ietf-teas-yang-te}}, needs enhancement 
-to support scenarios where multiple parallel TE paths are used in 
-load-balancing to carry traffic between two end-points (e.g., VPN 
+Although not analyzed in this document, it has been noted that the TE
+Tunnel model, defined in {{!I-D.ietf-teas-yang-te}}, needs enhancement
+to support scenarios where multiple parallel TE paths are used in
+load-balancing to carry traffic between two end-points (e.g., VPN
 traffic between two PEs).
 
 # Security Considerations {#security}

--- a/draft-ietf-teas-actn-poi-applicability.md
+++ b/draft-ietf-teas-actn-poi-applicability.md
@@ -803,9 +803,9 @@ discovery and path setup are typically vendor-specific and outside
 the scope of this document.
 
 Depending on the optical network type, TE topology abstraction, path 
-computation, and path setup can be single-layer (either OTN or WDM) 
+computation, and path setup can be single-layer (either OTN or DWDM) 
 or multi-layer OTN/WDM. In the latter case, multi-layer coordination 
-between the OTN and WDM layers is handled by the O-PNC.
+between the OTN and DWDM layers is handled by the O-PNC.
 
 {: #mpi}
 
@@ -1054,8 +1054,8 @@ inventory information of their equipment used by the different
 management layers. In the context of POI, the inventory information
 of IP and optical equipment can complement the topology views and
 facilitate the packet/optical multi-layer view, e.g., by providing a
-mapping between the lowest level LTPs in the topology view and
-corresponding ports in the network inventory view.
+mapping between the lowest level link termination points (LTPs) in 
+the topology view and corresponding ports in the network inventory view.
 
 The MDSC could also discover the entire network inventory information
 of both IP and optical equipment and correlate this information with
@@ -1080,13 +1080,14 @@ inventory/topology/service change occurs.
 
 It should also be possible to correlate information from IP and
 optical layers (e.g., which port, lambda/OTSi, and direction are used
-by a specific IP service on the WDM equipment).
+by a specific IP service on the DWDM equipment).
 
 In particular, for the cross-technology Ethernet links, it is key for
 MDSC to
 automatically correlate the information from the PNC network
 databases about the physical ports from the routers (single link or
-bundle links for LAG) to client ports in the ROADM.
+bundle links for Link Aggregation Group (LAG)) to client ports in the 
+ROADM.
 
 The analysis of multi-layer fault management is outside the scope of
 this document. However, the discovered information should be
@@ -1104,7 +1105,7 @@ notifications.
 ## Optical Topology Discovery
 
 The WSON Topology Model and the Flexi-grid Topology model can be used
-to report the DWDM network topology (e.g., WDM nodes and OMS links),
+to report the DWDM network topology (e.g., DWDM nodes and OMS links),
 depending on whether the DWDM optical network is based on fixed-grid
 or flexible-grid or a mix of fixed-grid and flexible-grid.
 
@@ -1177,10 +1178,10 @@ The optical transponders and, optionally, the OTN access cards, are
 abstracted at MPI by the O-PNC as Trail Termination Points (TTPs),
 defined in {{!RFC8795}}, within the optical network topology. This
 abstraction is valid independently of the fact that optical
-transponders are physically integrated within the same WDM node or
-are physically located on a device external to the WDM node since it
-both cases the optical transponders and the WDM node are under the
-control of the same O-PNC and abstracted as a single WDM TE Node at the
+transponders are physically integrated within the same DWDM node or
+are physically located on a device external to the DWDM node since it
+both cases the optical transponders and the DWDM node are under the
+control of the same O-PNC and abstracted as a single DWDM TE Node at the
 O-MPI.
 
 The association between the Ethernet or CBR client LTPs terminating
@@ -1202,7 +1203,7 @@ mechanisms which are outside the scope of this document, and reported
 at the MPIs within the optical network topology.
 
 In case of a multi-layer DWDM/OTN network domain, multi-layer
-intra-domain OTN links are supported by underlay WDM tunnels: this
+intra-domain OTN links are supported by underlay DWDM tunnels: this
 relationship is reported by the mechanisms described in
 {{optical-path-discovery}}.
 
@@ -1210,7 +1211,7 @@ relationship is reported by the mechanisms described in
 
 ## Optical Path Discovery
 
-The WDM Tunnel Model is used to report all the WDM tunnels
+The DWDM Tunnel Model is used to report all the DWDM tunnels
 established within the optical network.
 
 When the OTN switching layer is deployed within the optical domain,
@@ -1221,15 +1222,15 @@ The Ethernet client signal model and the Transparent CBR client
 signal model are used to report all the connectivity services
 provided by the underlay optical tunnels between Ethernet or CBR
 client LTPs, depending on whether the connectivity service is frame-based
-or transparent. The underlay optical tunnels can be either WDM
+or transparent. The underlay optical tunnels can be either DWDM
 tunnels or, when the optional OTN switching layer is deployed, OTN
 tunnels.
 
-The WDM tunnels can be used to support either Ethernet or CBR client
+The DWDM tunnels can be used to support either Ethernet or CBR client
 signals or multi-layer intra-domain OTN links. In the latter case,
 the hierarchical-link container, defined in {{!I-D.ietf-teas-yang-te}},
 associates
-the underlay WDM tunnel with the supported multi-layer intra-domain
+the underlay DWDM tunnel with the supported multi-layer intra-domain
 OTN link and it allows discovery of the multi-layer path supporting
 all the connectivity services provided by the optical network.
 
@@ -1282,9 +1283,9 @@ Ethernet links or access links, as described in detail in
 and in {{multi-technology-link-discovery}}.
 
 All the intra-domain Ethernet and IP links are discovered by the
-P-PNCs, using mechanisms, such as LLDP {{IEEE_802.1AB}}, which are
-outside the scope of this document, and reported at the MPIs within
-the Ethernet or the packet network topology.
+P-PNCs, using mechanisms, such as Link Layer Discover Protocol LLDP 
+{{IEEE_802.1AB}}, which are outside the scope of this document, and 
+reported at the MPIs within the Ethernet or the packet network topology.
 
 {: #te-path-discovery}
 
@@ -1844,7 +1845,7 @@ underlay optical tunnel.
 
 Therefore, to set up a new multi-technology intra-domain IP link, 
 the MDSC requires the O-PNC to set up the optical tunnel (using either 
-the WDM Tunnel model or the OTN Tunnel model, if optional OTN switching 
+the DWDM Tunnel model or the OTN Tunnel model, if optional OTN switching 
 is supported) within the optical network and steer client traffic 
 between the two cross-technology Ethernet links over that optical tunnel, 
 using either the Ethernet Client Signal Model (for frame-based transport) 
@@ -1994,7 +1995,7 @@ of:
 SRLGs reported by the P-PNC using the packet TE topology model);
 
 - the optical path (e.g., the list of SRLGs reported by the O-PNC
-using the WDM or OTN tunnel model); and
+using the DWDM or OTN tunnel model); and
 
 - the cross-domain links (e.g., the list of SRLGs reported by the O-PNC
 and P-PNC respectively, using the WSON and/or flexi-grid, the
@@ -2021,7 +2022,7 @@ but cares have to be taken to avoid missing information.
 
 ## TE Path Setup and Update
 
-This version of the draft assumes that TE path setup and update at
+This document assumes that TE path setup and update at
 the MPI could be done using the generic TE tunnel YANG data model,
 defined in {{!I-D.ietf-teas-yang-te}}, with packet technology-specific
 augmentations, described in {{packet-yang}}.
@@ -2168,7 +2169,7 @@ flexible-grid DWDM network topologies but also the only viable option
 for a mixed CWDM and DWDM network topology.
 
 Although not applicable to this document, it has been noted that the 
-WDM tunnel model would also support optical tunnel setup in the case 
+DWDM tunnel model would also support optical tunnel setup in the case 
 of a mixed CWDM and DWDM network topology.
 
 Although not analyzed in this document, it has been noted that the TE 
@@ -2351,8 +2352,7 @@ requirements).
 
 Although the OSS/Orchestration layer interface is usually
 operator-specific, typically it would be using a RESTCONF/YANG interface
-with
-a more abstracted version of the MPI YANG data models used for
+with a more abstracted version of the MPI YANG data models used for
 network configuration (e.g. L3NM, L2NM).
 
 {{fig-service-request}} shows an example of possible control flow between
@@ -2434,17 +2434,17 @@ There can be two cases here:
 
 1. LAG was defined between the IP routers at the two ends. MDSC, after
 checking
-that optical layer is fine between the two edge WDM nodes, triggers
-the WDM edge node re-configuration so that the IP router's back-up port
+that optical layer is fine between the two edge DWDM nodes, triggers
+the DWDM edge node re-configuration so that the IP router's back-up port
 with its
-associated muxponder port can reuse the WDM tunnel that was already in
+associated muxponder port can reuse the DWDM tunnel that was already in
 use previously by the failed IP router port and adds the new link to
 the LAG on the failure side.
 
    While the ROADM reconfiguration takes place, IP/MPLS traffic is
    using the reduced bandwidth of the IP link bundle, discarding
    lower priority traffic if required. Once back-up port has been
-   reconfigured to reuse the existing WDM tunnel and the new link has
+   reconfigured to reuse the existing DWDM tunnel and the new link has
 been added
    to the LAG then original Bandwidth is recovered between the end
    routers.
@@ -2460,11 +2460,11 @@ or TI-LFA (MPLS based SR-TE case) through a protection port. At
 the same time MDSC, after checking that optical network connection
 is still fine, would trigger the reconfiguration of the back-up
 port of the IP router and of the muxponder to re-use the same
-WDM tunnel as the one used originally for the failed IP router port. Once
+DWDM tunnel as the one used originally for the failed IP router port. Once
 everything has been correctly configured, MDSC Global PCE could
 suggest to the operator to trigger a possible re-optimization of
 the back-up MPLS path to go back to the  MPLS primary path through
-the back-up port of the IP router and the original WDM tunnel if overall
+the back-up port of the IP router and the original DWDM tunnel if overall
 cost, latency etc. is improved. However, in this scenario, there
 is a need for protection port PLUS back-up port in the IP router
 which does not lead to clear port savings.
@@ -2482,7 +2482,7 @@ trunk port bit rate which will also determine the Baud-rate, the
 modulation format, the FEC etc.
 
 The controller, when asked to set up a client connectivity service,
-needs to find a WDM tunnel suitable to comply the DWDM port
+needs to find a DWDM tunnel suitable to comply the DWDM port
 parameters.
 
 The setup of a client connectivity service between two muxponders is
@@ -2492,20 +2492,20 @@ might be a 100Gb/s trunk port shared by ten 10GE client ports.
 
 The controller, when asked to set a 10GE client connectivity service
 between two muxponder's client ports, needs first to check whether
-there is already an existing WDM tunnel between the two muxponders
+there is already an existing DWDM tunnel between the two muxponders
 and then take different actions:
 
-1. if the WDM tunnel already exists, the controller needs only to
+1. if the DWDM tunnel already exists, the controller needs only to
 enable the 10GE client ports to establish the 10GE client
 connectivity service;
 
-2. if the WDM tunnel does not exist, the controller has to first
-establish the WDM tunnel, finding a proper optical path matching
+2. if the DWDM tunnel does not exist, the controller has to first
+establish the DWDM tunnel, finding a proper optical path matching
 the optical parameters of the two muxponders' trunk ports (e.g.,
 an OTSi carrying an OTU4), and then enable the 10GE client ports
 to establish the 10GE client connectivity service.
 
-Since multiple client connectivity services are sharing the same WDM
+Since multiple client connectivity services are sharing the same DWDM
 tunnel, a multiplexing label shall be assigned to each client
 connectivity service. The multiplexing label can either be a standard
 label (e.g., an OTN timeslot) or a vendor-specific label. The
@@ -2524,7 +2524,7 @@ the control of the same O-PNC, the configuration of the multiplexing
 label, regardless of whether it is a standard or vendor-specific
 label, can be done by the O-PNC using mechanisms which are
 vendor-specific and outside the scope of this document. The MDSC can just
-request the O-PNC to setup a client connectivity service over a WDM
+request the O-PNC to setup a client connectivity service over a DWDM
 tunnel.
 
 In case of fixed configuration, the multiplexing label is assigned by

--- a/draft-ietf-teas-actn-poi-applicability.md
+++ b/draft-ietf-teas-actn-poi-applicability.md
@@ -385,7 +385,7 @@ such as PE-BR, PE-P, BR-P, and P-P IP links. Consequently, inter-domain
 IP links are always single-technology connections, supported by
 single-technology Ethernet links between physically adjacent IP routers.
 
-As described in {{?RFC7424}, in order to increase the bandwidth between two adjacent routers multiple Ethernet links can be setup between adjacent routers using either Link Aggregation Groups (LAGs) {{IEEE_802.1AX}} or Equal Cost Multi-Path (ECMP) {{?RFC2991}}.
+As described in {{?RFC7424}}, in order to increase the bandwidth between two adjacent routers multiple Ethernet links can be setup between adjacent routers using either Link Aggregation Groups (LAGs) {{IEEE_802.1AX}} or Equal Cost Multi-Path (ECMP) {{?RFC2991}}.
 
 Therefore, if inter-domain links between optical domains exist, they
 would be utilized to support multi-domain optical services, which fall

--- a/draft-ietf-teas-actn-poi-applicability.md
+++ b/draft-ietf-teas-actn-poi-applicability.md
@@ -6,7 +6,8 @@ abbrev: ACTN POI
 category: info
 
 docname: draft-ietf-teas-actn-poi-applicability-latest
-submissiontype: IETF  # also: "independent", "editorial", "IAB", or "IRTF"
+submissiontype: IETF  # also: "independent", "editorial", "IAB", or
+"IRTF"
 number:
 date:
 consensus: true
@@ -23,7 +24,9 @@ venue:
   mail: "teas@ietf.org"
   arch: "https://mailarchive.ietf.org/arch/browse/teas/"
   github: "IETF-TEAS-WG/actn-poi"
-  latest: "https://IETF-TEAS-WG.github.io/actn-poi/draft-ietf-teas-actn-poi-applicability.html"
+  latest:
+"https://IETF-TEAS-WG.github.io/actn-poi/draft-ietf-teas-actn-poi-applica
+bility.html"
 
 author:
   -
@@ -57,8 +60,6 @@ contributor:
     name: Gabriele Galimberti
     email: ggalimbe56@gmail.com
   -
-    name: TBD
-  -
     name: Anton Snitser
     org: Cisco
     email: asnizar@cisco.com
@@ -76,7 +77,7 @@ contributor:
     email: younglee.tx@gmail.com
   -
     name: Jeff Tantsura
-    org: Apstra
+    org: Nvidia
     email: jefftant.ietf@gmail.com
   -
     name: Paolo Volpato
@@ -110,7 +111,8 @@ normative:
     seriesinfo: IEEE 802.1AB-2016
     target: https://ieeexplore.ieee.org/document/7433915
   IEEE_802.1AX:
-    title: "IEEE Standard for Local and metropolitan area networks - Link Aggregation"
+    title: "IEEE Standard for Local and metropolitan area networks - Link
+Aggregation"
     author:
       org: Institute of Electrical and Electronics Engineers
     date: December 2014
@@ -121,17 +123,17 @@ informative:
 
 --- abstract
 
-This document considers the applicability of Abstraction and Control
-of TE Networks (ACTN) architecture to Packet Optical Integration
-(POI) in the context of IP/MPLS and optical internetworking. It
-identifies the YANG data models defined by the IETF to support this
-deployment architecture and specific scenarios relevant to Service
-Providers.
+This document explores the applicability of the Abstraction and Control 
+of TE Networks (ACTN) architecture to Packet Optical Integration (POI) 
+within the context of IP/MPLS and optical internetworking. It examines 
+the YANG data models defined by the IETF that enable an ACTN-based 
+deployment architecture and highlights specific scenarios pertinent 
+to Service Providers.
 
-Existing IETF protocols and data models are identified for each
-multi-technology (packet over optical) scenario with a specific focus on
-the MPI (Multi-Domain Service Coordinator to Provisioning Network
-Controllers Interface)in the ACTN architecture.
+Existing IETF protocols and data models are identified for each 
+multi-technology scenario (packet over optical), particularly 
+emphasising the Multi-Domain Service Coordinator to Provisioning 
+Network Controller Interface (MPI) within the ACTN architecture
 
 --- middle
 
@@ -139,70 +141,79 @@ Controllers Interface)in the ACTN architecture.
 
 # Introduction
 
-The complete automation of the management and control of Service
-Providers transport networks (IP/MPLS, optical, and microwave
-transport networks) is vital for meeting emerging demand for high-bandwidth use cases, including 5G and fiber connectivity services.
-The Abstraction and Control of TE Networks (ACTN) architecture and
-interfaces facilitate the automation and operation of complex optical
-and IP/MPLS networks through standard interfaces and data models.
-This allows a wide range of network services that can be requested by
-the upper layers fulfilling almost any kind of service level
-requirements from a network perspective (e.g. physical diversity,
-latency, bandwidth, topology, etc.)
+The full automation of management and control for Service Providers'
+transport  networks—spanning IP/MPLS, optical, and microwave
+technologies—is crucial to addressing customer demands for high-bandwidth
+applications, such as ultra-fast  mobile broadband for 5G and fiber
+connectivity services. The Abstraction and  Control of TE Networks (ACTN)
+architecture and interfaces enable the automation  and efficient
+operation of complex optical and IP/MPLS networks using standardized 
+interfaces and data models. This approach supports a broad spectrum of
+network  services that can be requested by upper-layer applications,
+meeting diverse  service-level requirements from a network perspective,
+such as physical diversity, latency, bandwidth, and topology.
 
-Packet Optical Integration (POI) is an advanced use case of traffic
-engineering. In wide-area networks, a packet network based on the
-Internet Protocol (IP), and often Multiprotocol Label Switching
-(MPLS) or Segment Routing (SR), is typically realized on top of an
-optical transport network that uses Dense Wavelength Division
-Multiplexing (DWDM)(and optionally an Optical Transport Network
-(OTN)layer).
+Packet Optical Integration (POI) represents an advanced application of
+traffic engineering. In wide-area networks, packet networks based on the
 
-In many existing network deployments, the packet and the optical
-networks are engineered and operated independently. As a result,
-there are technical differences between the technologies (e.g.,
-routers compared to optical switches) and the corresponding network
-engineering and planning methods (e.g., inter-domain peering
-optimization in IP, versus dealing with physical impairments in DWDM,
-or very different time scales). In addition, customers needs can be
-different between a packet and an optical network, and it is not
-uncommon to use other vendors in both domains. The operation of these
-complex packet and optical networks is often siloed, as these
-technology domains require specific skill sets.
+Internet Protocol (IP), often augmented with Multiprotocol Label 
+Switching (MPLS) or Segment Routing  (SR), are typically implemented over
 
-The packet/optical network deployment and operation separation are
-inefficient for many reasons. First, both capital expenditure (CAPEX)
-and operational expenditure (OPEX) could be significantly reduced by
-integrating the packet and the optical networks. Second, multi-technology
-online topology insight can speed up troubleshooting (e.g., alarm
-correlation) and network operation (e.g., coordination of maintenance
-events), and multi-technology offline topology inventory can improve
-service quality (e.g., detection of diversity constraint violations).
-Third, multi-technology traffic engineering can use the available network
-capacity more efficiently (e.g., coordination of restoration). In
-addition, provisioning workflows can be simplified or automated
-across layers (e.g., to achieve bandwidth-on-demand or to perform
-activities during maintenance windows).
+an optical transport network utilizing Dense Wavelength Division 
+Multiplexing (DWDM), occasionally with an optional Optical Transport 
+Network (OTN) layer.
+
+In many existing network deployments, packet and optical networks are
+engineered and operated independently. This separation results in
+significant technical differences between the two technologies (e.g.,
+routers versus optical switches) and their associated network engineering
+and planning approaches (e.g., inter-domain peering optimization in IP
+networks versus managing physical impairments in DWDM systems or
+operating on vastly different time scales). Additionally, customer
+requirements often differ between packet and optical networks, and it is
+common for Service Providers to use different vendors for each domain. As
+a result, the operation of these complex packet and optical networks is
+often siloed, as each technology domain requires specialized skill sets.
+
+The separation of packet and optical network deployment and operation is
+inefficient for several reasons. First, integrating packet and optical
+networks can significantly reduce both capital expenditures (CAPEX) and
+operational expenditures (OPEX). Second, multi-technology online topology
+insights can accelerate troubleshooting (e.g., alarm correlation) and
+improve network operations (e.g., coordination of maintenance events),
+while multi-technology offline topology inventories can enhance service
+quality (e.g., detection of diversity constraint violations). Third,
+multi-technology traffic engineering enables more efficient use of
+available network capacity (e.g., coordination of restoration).
+Furthermore, provisioning workflows can be simplified or automated across
+layers, facilitating capabilities such as bandwidth-on-demand and
+streamlined maintenance activities.
+
 
 This document uses packet-based Traffic Engineered (TE) service
 examples. These are described as "TE-path" in this document. Unless
-otherwise stated, these TE services may be instantiated using RSVP-TE-based or SR-TE-based, forwarding plane mechanisms.
+otherwise stated, these TE services may be instantiated using
+Resource Reservation Protocol (RSVP) Traffic Engineering (TE)-based or SR
 
-The ACTN framework enables the complete multi-technology and multi-vendor
-integration of packet and optical networks through a Multi-Domain
-Service Coordinator (MDSC), and packet and optical Provisioning
-Network Controllers (PNCs).
+-TE-based, forwarding plane mechanisms.
 
-This document describes critical scenarios for POI from the packet
-service layer perspective and identifies the required coordination
-between packet and optical layers to improve POI deployment and
-operation. These scenarios focus on multi-domain packet networks
-operated as a client of optical networks.
+The ACTN framework facilitates seamless integration of packet and optical
+networks across multiple technologies and vendors. This is achieved
+through the coordination of a Multi-Domain Service Coordinator (MDSC) and
+Provisioning Network Controllers (PNCs) for both packet and optical
+domains.
 
-This document analyses the case where the packet networks support
-multi-domain TE paths. The optical networks could be either a DWDM
-network, an OTN network (without DWDM layer), or a multi-layer
-OTN/DWDM network. Furthermore, DWDM networks could be either fixed-grid or flexible-grid.
+This document outlines key scenarios for Packet Optical Integration (POI)
+from the perspective of the packet service layer and highlights the
+necessary coordination between packet and optical layers to enhance POI
+deployment and operation. These scenarios emphasize multi-domain packet
+networks functioning as clients of optical networks.
+
+This document analyzes the scenario in which packet networks support
+multi-domain TE paths. The optical networks may
+consist of a DWDM network, an OTN network (without a DWDM layer), or a
+multi-layer OTN/DWDM network. Additionally, DWDM networks can be either
+fixed-grid or flexible-grid.
 
 Multi-technology and multi-domain scenarios, based on the reference
 network described in {{reference-network}} and very relevant for Service
@@ -218,10 +229,10 @@ interfaces and data models of the ACTN architecture.
 A summary of the gaps identified in this analysis is provided in
 {{conclusions}}.
 
-Understanding the level of standardization and the possible gaps will
-help assess the feasibility of integration between packet and optical
-DWDM domains (and optionally OTN layer) in an end-to-end multi-vendor
-service provisioning perspective.
+Understanding the degree of standardization and identifying potential
+gaps are crucial for evaluating the feasibility of integrating packet and
+optical DWDM domains (with an optional OTN layer) from an end-to-end,
+multi-vendor service provisioning perspective.
 
 {: #terms}
 
@@ -232,20 +243,25 @@ This document uses the ACTN terminology defined in {{!RFC8453}}.
 In addition, this document uses the following terminology.
 
 Customer service:
-: The end-to-end service from CE to CE.
+: The end-to-end service from Customer Edge (CE) to CE.
 
 Network service:
-: The PE to PE configuration, including both the network service
-layer (VRFs, RT import/export policies configuration) and the
-network transport layer (e.g. RSVP-TE LSPs). This includes the
-configuration (on the PE side) of the interface towards the CE
-(e.g. VLAN, IP address, routing protocol etc.).
+: The Provider Edge (PE) to PE configuration, including both the network
+
+service layer (VRFs, RT import/export policies configuration) and the
+network transport layer (e.g. RSVP-TE Label Switched Paths (LSPs). This 
+includes the configuration (on the PE side) of the interface towards the
+
+CE (e.g. VLAN, IP address, routing protocol, etc.).
 
 Technology domain:
-: short for "switching technology domain", defined as "region" in {{!RFC5212}}, where the term "region" is applied to (GMPLS) control domains.
+: short for "switching technology domain", defined as "region" in
+{{!RFC5212}}, where the term "region" is applied to (GMPLS) control
+domains.
 
 PNC Domain:
-: part of the network under control of a single PNC instance. It is subject to the capabilities of the PNC which technology is controlled.
+: part of the network under control of a single PNC instance. It is
+subject to the capabilities of the PNC which technology is controlled.
 
 Port:
 : The physical entity that transmits and receives physical signals.
@@ -254,7 +270,8 @@ Interface:
 : A physical or logical entity that transmits and receives traffic.
 
 Link:
-: An association between two interfaces that can exchange traffic directly.
+: An association between two interfaces that can exchange traffic
+directly.
 
 Intra-domain link:
 : a link between two adjacent nodes that belong to the same PNC domain.
@@ -266,22 +283,30 @@ Ethernet link:
 : A link between two Ethernet interfaces.
 
 Single-technology Ethernet link:
-: An Ethernet link between two Ethernet interfaces on physically adjacent IP routers.
+: An Ethernet link between two Ethernet interfaces on physically adjacent
+IP routers.
 
 Multi-technology Ethernet link:
-: An Ethernet link between two Ethernet interfaces on logically adjacent IP routers, which is supported by two cross-technology Ethernet links and an optical tunnel in between.
+: An Ethernet link between two Ethernet interfaces on logically adjacent
+IP routers, supported by two cross-technology Ethernet links
+interconnected through an optical tunnel.
 
 Cross-technology Ethernet link:
-: An Ethernet link between an Ethernet interface on an IP router and an Ethernet interface on a physically adjacent optical node.
+: An Ethernet link connecting an Ethernet interface on an IP router to an
+Ethernet interface on a physically adjacent optical node.
 
 Inter-domain Ethernet link:
-: An Ethernet link between two Ethernet interfaces on physically adjacent IP routers that belong to different P-PNC domains.
+: An Ethernet link between two Ethernet interfaces on physically adjacent
+IP routers that belong to different P-PNC domains.
 
 Single-technology intra-domain Ethernet link:
-: An Ethernet link between two Ethernet interfaces on physically adjacent IP routers that belong to the same P-PNC domain.
+: An Ethernet link between two Ethernet interfaces on physically adjacent
+IP routers that belong to the same P-PNC domain.
 
 Multi-technology intra-domain Ethernet link:
-: An Ethernet link between two Ethernet interfaces on logically adjacent IP routers that belong to the same P-PNC domain, which is supported by two cross-technology Ethernet links and an optical tunnel in between.
+: An Ethernet link between two Ethernet interfaces on logically adjacent
+IP routers within the same P-PNC domain, supported by two
+cross-technology Ethernet links interconnected through an optical tunnel.
 
 IP link:
 : A link between two IP interfaces.
@@ -297,56 +322,57 @@ Multi-technology intra-domain IP link:
 
 # Reference Network Architecture {#reference-network}
 
-This document analyses several deployment scenarios for Packet and
-Optical Integration (POI) in which ACTN hierarchy is deployed to
-control a multi-technology and multi-domain network with two optical
-domains and two packet domains, as shown in {{fig-ref-network}}:
+This document examines various deployment scenarios for Packet and
+Optical Integration (POI), where the ACTN hierarchy is implemented to
+manage a multi-technology, multi-domain network comprising two optical
+domains and two packet domains, as illustrated in {{fig-ref-network}}:
 
 {::include ./figures/reference-network.md}
 {: #fig-ref-network title="Reference Network"}
 
-The ACTN architecture, defined in {{!RFC8453}}, is used to control this
-multi-technology and multi-domain network where each Packet PNC (P-PNC) is
-responsible for controlling its packet domain and where each Optical
-PNC (O-PNC) in the above topology is responsible for controlling its
-optical domain. The packet domains controlled by the P-PNCs can be
-Autonomous Systems (ASes), defined in {{?RFC1930}}, or IGP areas, within
-the same operator network.
-
+The ACTN architecture, as defined in {{!RFC8453}}, is utilized to manage
+this multi-technology, multi-domain network. In this topology, each
+Packet PNC (P-PNC) is responsible for controlling its respective packet
+domain, while each Optical PNC (O-PNC) is tasked with managing its
+optical domain. The packet domains controlled by the P-PNCs can represent
+Autonomous Systems (ASes), as defined in {{?RFC1930}}, or Interior
+Gateway Protocol (IGP) areas within the same operator network.
 The IP routers between the packet domains can be either AS Boundary
 Routers (ASBR) or Area Border Router (ABR): in this document, the
 generic term Border Router (BR) is used to represent either an ASBR
 or an ABR.
 
-The MDSC is responsible for coordinating the whole multi-domain
-multi-technology (packet and optical) network. A specific standard
-interface (MPI) permits MDSC to interact with the different
-Provisioning Network Controller (O/P-PNCs).
+The Multi-Domain Service Coordinator (MDSC) is responsible for
+orchestrating the entire multi-domain, multi-technology network,
+encompassing both packet and optical domains. A standardized interface,
+the Multi-Domain Service Coordinator to Provisioning Network Controller
+Interface (MPI), enables the MDSC to interact with various Provisioning
+Network Controllers (O-PNCs and P-PNCs).
 
-The MPI interface presents an abstracted topology to MDSC, hiding
-technology-specific aspects of the network and hiding topology
-details depending on the policy chosen regarding the level of
-abstraction supported. The level of abstraction can be obtained based
-on P-PNC and O-PNC configuration parameters (e.g., provide the
-potential connectivity between any PE and any BR in a packet
-network).
+The MPI interface provides the MDSC with an abstracted topology,
+concealing technology-specific details of the network and selectively
+hiding topology information based on the chosen abstraction policy. The
+level of abstraction is determined by the configuration parameters of the
+P-PNC and O-PNC, such as offering potential connectivity information
+between any Provider Edge (PE) and Border Router (BR) within a packet
+network.
 
 In the reference network of {{fig-ref-network}}, it is assumed that:
 
-- The domain boundaries between the packet and optical domains are
-congruent. In other words, one optical domain supports
-connectivity between IP routers in one and only one packet domain;
+- The domain boundaries of the packet and optical domains are
+congruent. In other words, each optical domain exclusively supports
+connectivity between IP routers within a single packet domain.;
 
-- There are no inter-domain physical links between optical domains.
-Inter-domain physical links exist only:
+- There are no physical links directly connecting optical domains.
+Inter-domain physical links exist only under the following conditions:
 
   - between packet domains (i.e., between BRs belonging to
   different packet domains): these links are called inter-domain
   Ethernet or IP links within this document;
 
   - between packet and optical domains (i.e., between routers and
-  optical nodes): these links are called cross-technology Ethernet links within
-  this document;
+  optical nodes): these links are called cross-technology Ethernet links
+  within this document;
 
   - between customer sites and the packet network (i.e., between
   CE devices and PE routers): these links are called access
@@ -355,104 +381,111 @@ Inter-domain physical links exist only:
 -  All the physical interfaces at inter-domain links are Ethernet
 physical interfaces.
 
-Although the new optical technologies (e.g., QSFP-DD ZR 400G) allow
-the operators to provide DWDM pluggable interfaces on the IP routers,
-the deployment of those pluggable optics is not yet widely adopted.
-The reason is that most operators are not yet ready to manage packet
-and optical networks in a single unified domain. Therefore, a unified
-use case analysis is outside the scope of this document.
+Although emerging optical technologies (e.g., QSFP-DD ZR 400G) enable
+operators to deploy DWDM pluggable interfaces on IP routers, the adoption
+of these technologies remains limited. This is primarily because most
+operators are not yet prepared to manage packet and optical networks
+within a single unified domain. Consequently, a unified use case analysis
+falls outside the scope of this document.
 
-This document analyses scenarios where all the multi-technology IP links,
-supported by the optical network, are intra-domain (intra-AS/intra-area), such as PE-BR, PE-P, BR-P, P-P IP links. Therefore the inter-domain IP links are always single-technology links supported by single-technology Ethernet
-links between physically adjacent IP routers.
+This document analyzes scenarios in which all multi-technology IP links
+supported by the optical network are intra-domain (intra-AS/intra-area),
+such as PE-BR, PE-P, BR-P, and P-P IP links. Consequently, inter-domain
+IP links are always single-technology connections, supported by
+single-technology Ethernet links between physically adjacent IP routers.
 
-Therefore, if inter-domain links between the optical domains exist,
-they would be used to support multi-domain optical services, which
-are outside the scope of this document.
+Therefore, if inter-domain links between optical domains exist, they
+would be utilized to support multi-domain optical services, which fall
+outside the scope of this document.
 
 The optical nodes within the optical domains can be either:
 
-- WDM nodes, as defined in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}}, with an integrated ROADM functions and with or without integrated optical transponders;
+- DWDM nodes, as defined in
+{{?I-D.ietf-ccamp-optical-impairment-topology-yang}}, with an integrated
+ROADM functions and with or without integrated optical transponders;
 
-- OTN nodes, with integrated an OTN cross-connect function and with or without integrated ROADM functions or optical transponders.
+- OTN nodes, with integrated an OTN cross-connect function and with or
+without integrated ROADM functions or optical transponders.
 
 {: #mdsc-overview}
 
 ## Multi-domain Service Coordinator (MDSC) functions
 
-The MDSC in {{fig-ref-network}} is responsible for multi-domain and multi-technology
-coordination across multiple packet and optical domains and provides
-multi-layer/multi-domain L2/L3 VPN network services requested by an
-OSS/Orchestration layer.
+The MDSC in {{fig-ref-network}} is responsible for coordinating multiple
+packet and optical domains in a multi-domain, multi-technology
+environment. It facilitates multi-layer and multi-domain L2/L3 VPN
+network services as requested by the OSS/Orchestration layer.
 
 From an implementation perspective, the functions associated with
 MDSC described in {{!RFC8453}} may be grouped differently.
 
-1. The service- and network-related functions are collapsed into a
-single, monolithic implementation, dealing with the end customer
-service requests received from the CMI (Customer MDSC Interface)
-and adapting the relevant network models. An example is represented
-in Figure 2 of {{!RFC8453}}.
+1. The service-related and network-related functions are combined into a
+single, monolithic implementation. This implementation manages
+end-customer service requests received through the Customer MDSC
+Interface (CMI) and adapts the corresponding network models. An example
+of this architecture is illustrated in Figure 2 of {{!RFC8453}}.
 
-1. An implementation can choose to split the service-related and the
-network-related functions into different functional entities, as
-described in {{?RFC8309}} and in section 4.2 of {{!RFC8453}}. In this
-case, MDSC is decomposed into a top-level Service Orchestrator,
-interfacing the customer via the CMI, and into a Network
-Orchestrator interfacing at the southbound with the PNCs. The
-interface between the Service Orchestrator and the Network
+1. An implementation may opt to separate the service-related and
+network-related functions into distinct functional entities, as outlined
+in {{?RFC8309}} and Section 4.2 of {{!RFC8453}}. In this approach, the
+MDSC is decomposed into a top-level Service Orchestrator, which
+interfaces with the customer through the Customer MDSC Interface (CMI),
+and a Network Orchestrator, which interfaces southbound with the PNCs.
+The interface between the Service Orchestrator and the Network
 Orchestrator is not specified in {{!RFC8453}}.
 
-1. Another implementation can choose to split the MDSC functions
-between an "higher-level MDSC" (MDSC-H) responsible for packet and
-optical multi-technology coordination, interfacing with one Optical
-"lower-level MDSC" (MDSC-L), providing multi-domain coordination
-between the O-PNCs and one Packet MDSC-L, providing multi-domain
-coordination between the P-PNCs (see for example Figure 9 of
-{{!RFC8453}}).
+1. Another implementation may choose to split the MDSC functions into a
+"higher-level MDSC" (MDSC-H) and "lower-level MDSCs" (MDSC-Ls). The
+MDSC-H is responsible for multi-technology coordination across packet and
+optical domains, while the MDSC-Ls handle domain-specific coordination.
+Specifically, an Optical MDSC-L manages multi-domain coordination between
+the O-PNCs, and a Packet MDSC-L manages multi-domain coordination between
+the P-PNCs. This approach is illustrated, for example, in Figure 9 of
+{{!RFC8453}}.
 
-1. Another implementation can also choose to combine the MDSC and the
-P-PNC functions.
+1. An alternative implementation may choose to integrate the MDSC and
+P-PNC functions into a single entity.
 
-In the current service provider's network deployments, at the North
-Bound of the MDSC, instead of a CNC, typically, there is an
-OSS/Orchestration layer. In this case, the MDSC would implement only
-the Network Orchestration functions, as in {{?RFC8309}} described in
-point 2 above. Therefore, the MDSC deals with the network services
-requests received from the OSS/Orchestration layer.
+In current service provider network deployments, the MDSC's Northbound
+Interface (NBI) typically connects to an OSS/Orchestration layer rather
+than a CNC. In this scenario, the MDSC is limited to performing Network
+Orchestration functions, as described in {{?RFC8309}} (point 2 above).
+Consequently, the MDSC handles network service requests received from the
+OSS and/or Orchestration.
 
-The functionality of the OSS/Orchestration layer and the interface
-toward the MDSC are usually operator-specific and outside the scope
-of this draft. Therefore, this document assumes that the
-OSS/Orchestrator requests the MDSC to set up L2/L3 VPN network
-services through mechanisms outside this document's scope.
+The functionality of the OSS and/or Orchestration layer, as well as its
+interface with the MDSC, is typically operator-specific and falls outside
+the scope of this draft. Therefore, this document assumes that the OSS
+and/or Orchestration layer requests the MDSC to provision L2/L3 VPN
+network services through mechanisms not covered in this document.
 
 There are two prominent workflow cases when the MDSC multi-technology
 coordination is initiated:
 
--  Initiated by request from the OSS/Orchestration layer to setup
+-  Initiated by request from the OSS and/or Orchestration  layer to setup
 L2/L3 VPN network services that require multi-layer/multi-domain
 coordination;
 
--  The MDSC initiates them to perform multi-layer/multi-domain
-optimizations and/or maintenance activities (e.g. rerouting LSPs
-with their associated services when putting a resource, like a
-fibre, in maintenance mode during a maintenance window).
-Unlike service fulfillment, these workflows are not related to a
-network service provisioning request received from
-the OSS/Orchestration layer.
+-  The MDSC initiates these workflows to perform multi-layer and
+multi-domain optimizations and/or maintenance activities (e.g., rerouting
+LSPs and their associated services when a resource, such as a fiber, is
+placed in maintenance mode during a maintenance window). Unlike service
+fulfillment, these workflows are not triggered by a network service
+provisioning request from the OSS or Orchestration layer.
 
 The latter workflow cases are outside the scope of this document.
 
-This document analyses the use cases where multi-layer coordination
-is triggered by a network service request received from the
-OSS/Orchestration layer.
+This document examines use cases in which multi-layer coordination is
+initiated by a network service request from the OSS and/or Orchestration
+layer.
 
 {: #vpn-overview}
 
 ### Multi-domain L2/L3 VPN Network Services
 
-{{fig-vpn-topo}} and {{fig-vpn-path}} provide an example of a hub & spoke multi-domain L2/L3 VPN with three PEs where the hub PE (PE13) and one spoke
+{{fig-vpn-topo}} and {{fig-vpn-path}} provide an example of a hub & spoke
+multi-domain L2/L3 VPN with three PEs where the hub PE (PE13) and one
+spoke
 PE (PE14) are within the same packet domain, and the other spoke PE
 (PE23) is within a different packet domain.
 
@@ -465,46 +498,51 @@ PE (PE14) are within the same packet domain, and the other spoke PE
 There are many options to implement multi-domain L2/L3 VPNs,
 including:
 
-1. BGP-LU ({{?RFC8277}})
+1. BGP-Labeled Unicast (BGP-LU) ({{?RFC8277}})
 
 1. Inter-domain RSVP-TE
 
 1. Inter-domain SR-TE
 
-This document analyses the inter-domain TE options for which the TE
-tunnel model, defined in {{!I-D.ietf-teas-yang-te}}, could be used at the MPI for
-intra-domain or inter-domain TE configuration. The analysis of other
-options is outside the scope of this draft.
+This document explores inter-domain TE options where the TE tunnel model,
+as defined in {{!I-D.ietf-teas-yang-te}}, applies at the MPI for both
+intra-domain and inter-domain TE configurations. The assessment of
+alternative options is beyond the scope of this draft.
 
 It is also assumed that:
 
 - the bandwidth of each intra-domain TE path is managed by its
 respective P-PNC;
 
-- technology-specific mechanisms (in the case of inter-domain SR-TE,
-the binding SID) are used for the inter-domain TE path stitching;
+- technology-specific mechanisms are employed for inter-domain TE path
+stitching. In the case of inter-domain SR-TE, a Segment Identifier (SID)
+is used in Segment Routing (SR) to define a segment (a portion of the
+path) within a network. A binding SID, a special type of SID, acts as a
+reference to a precomputed SR policy or path.
 
-- each packet domain in {{fig-vpn-topo}} uses technology-specific local protection mechanisms (such as Fast Reroute (FRR) in case of MPLS-TE or Topology Independent Loop-free Alternate Fast Reroute (TI-LFA) in case of SR-TE), with the awareness of multi-technology TE path properties (e.g., SRLG).
+- each packet domain in {{fig-vpn-topo}} employs technology-specific
+local protection mechanisms, such as Fast Reroute (FRR) for MPLS-TE or
+Topology Independent Loop-Free Alternate (TI-LFA) for SR-TE. These
+mechanisms operate with an awareness of multi-technology TE path
+properties, such as Shared Risk Link Group (SRLG).
 
-In the case of inter-domain TE-paths, it is also assumed that each
-packet domain in {{fig-vpn-topo}} and {{fig-vpn-path}} implements the same TE
-technology, and the stitching between two domains is done using
-inter-domain TE.
+For inter-domain TE paths, it is assumed that each packet domain in
+{{fig-vpn-topo}} and {{fig-vpn-path}} employs the same TE technology. The
+stitching between two domains is achieved using inter-domain TE
+mechanisms.
 
-In this scenario, one of the key MDSC functions is to identify the
-multi-domain/multi-layer TE paths to be used to carry the L2/L3 VPN
-traffic between PEs belonging to different packet domains and to
-relay this information to the P-PNCs, to ensure that the PEs'
-forwarding tables (e.g., VRF) are properly configured to steer the
-L2/L3 VPN traffic over the intended multi-domain/multi-layer TE
-paths.
+In this scenario, a key function of the MDSC is to identify the
+multi-domain and multi-layer TE paths for carrying L2/L3 VPN traffic
+between PEs in different packet domains. The MDSC then relays this
+information to the P-PNCs to ensure that the forwarding tables of the PEs
+(e.g., VRF) are correctly configured, allowing the L2/L3 VPN traffic to
+be routed over the designated multi-domain and multi-layer TE paths.
 
-The selection of the TE path should take into account the TE
-requirements and the binding requirements for the L2/L3 VPN network
-service.
+The selection of the TE path should consider both the TE requirements and
+the binding requirements of the L2/L3 VPN network service.
 
-In general, the binding requirements for a network service (e.g.,
-L2/L3 VPN) can be summarized within three cases:
+In general, the binding requirements for a network service (e.g., L2/L3
+VPN) can be categorized into three main cases:
 
 1. The customer is asking for VPN isolation to dynamically create
 and bind tunnels to the service so that they are not shared by
@@ -514,20 +552,21 @@ other services (e.g. VPN).
 
    {: type="a"}
 
-   1.  Hard isolation with deterministic latency means L2/L3 VPN
-   requires a set of dedicated TE Tunnels (neither sharing
-   with other services nor competing for bandwidth with other
-   tunnels), providing deterministic latency performances
+   1.  Hard isolation with deterministic latency implies that the L2/L3
+       VPN requires a set of dedicated TE tunnels. These tunnels neither
 
-   1.  hard isolation but without deterministic characteristics
+       share resources with other services nor compete for bandwidth with
+
+       other tunnels, ensuring deterministic latency performance.
+
+   1.  Hard isolation but without deterministic characteristics
 
    1.  Soft isolation means the tunnels associated with L2/L3 VPN
-   are dedicated to that but can compete for bandwidth with
-   other tunnels.
+       are dedicated to that but can compete for bandwidth with
+       other tunnels.
 
-1. The customer does not ask for isolation and could request a VPN
-service where associated tunnels can be shared across multiple
-VPNs.
+1. The customer does not require isolation and may request a VPN service
+where the associated tunnels are shared across multiple VPNs.
 
 For each TE path required to support the L2/L3 VPN network service,
 it is possible that:
@@ -544,7 +583,8 @@ increase) to meet the TE and binding requirements:
    layer.
 
    1. One or more new underlay optical tunnels need to be setup to
-   support the requested changes of the overlay TE paths (multi-layer coordination is required).
+   support the requested changes of the overlay TE paths (multi-layer
+coordination is required).
 
 1. A new TE path needs to be setup to meet the TE and binding
 requirements:
@@ -557,135 +597,135 @@ requirements:
    support the setup of the new TE path  (multi-layer
    coordination is required).
 
-This document analyses scenarios where only one TE path is used to
-carry the VPN traffic between PEs. Scenarios, where multiple parallel
-TE paths are used in load-balancing to carry the VPN traffic between
-PEs, are possible but their analysis is outside the scope of this
-document.
+This document examines scenarios in which a single TE path is used to
+carry VPN traffic between PEs. Scenarios involving multiple parallel TE
+paths for load-balancing VPN traffic between PEs are possible but are
+beyond the scope of this document.
 
 {: #path-computation-overview}
 
 ### Multi-domain and Multi-layer Path Computation
 
-When a new TE path needs to be setup, the MDSC is also responsible
-for coordinating the multi-layer/multi-domain path computation.
+When establishing a new TE path, the MDSC is responsible for coordinating
+the path computation across multiple layers and domains.
 
-Depending on the knowledge that MDSC has of the topology and
-configuration of the underlying network domains, three approaches for
-performing multi-layer/multi-domain path computation are possible:
+Based on the MDSC's knowledge of the underlying network topology and 
+configuration, three approaches for multi-layer and multi-domain path 
+computation are possible:
 
-1. Full Summarization: In this approach, the MDSC has an abstracted
-TE topology view of all of its packet and optical, underlying
-domains.
+1. Full Summarization: In this approach, the MDSC maintains an abstracted
+TE topology view of all its packet and optical underlying domains.
 
-   In this case, the MDSC does not have enough TE topology
-   information to perform multi-layer/multi-domain path computation.
-   Therefore the MDSC delegates the P-PNCs and O-PNCs to perform
-   local path computation within their respective controlled domains.
-   Then, it uses the information returned by the P-PNCs and O-PNCs to
-   compute the optimal multi-domain/multi-layer path.
+   In this case, the MDSC lacks sufficient TE topology information to 
+   perform multi-layer/multi-domain path computation. It delegates the 
+   P-PNCs and O-PNCs to compute local paths within their respective 
+   domains, then uses the returned information to compute the optimal 
+   multi-domain/multi-layer path.
 
-   This approach presents an issue to P-PNC, which does not have the
-   capability of performing a single-domain/multi-layer path
-   computation, since it can not retrieve the topology information
-   from the O-PNCs nor delegate the O-PNC to perform optical path
-   computation.
+   This approach presents an issue for the P-PNC, as it lacks the ability 
+   to perform single-domain/multi-layer path computation. It cannot 
+   retrieve topology information from the O-PNCs or delegate optical path 
+   computation to the O-PNCs. A possible solution is to include a CNC 
+   function within the P-PNC to request the MDSC for multi-domain 
+   optical path computation, as shown in Figure 10 of {{!RFC8453}}.
 
-   A possible solution could include a CNC function within the P-PNC
-   to request the MDSC multi-domain optical path computation, as
-   shown in Figure 10 of {{!RFC8453}}.
+   Another solution could involve relying on the MDSC recursive hierarchy, 
+   as defined in Section 4.1 of {{!RFC8453}}, where each IP and optical 
+   domain pair has a "lower-level MDSC" (MDSC-L) for multi-layer 
+   correlation, and a "higher-level MDSC" (MDSC-H) for multi-domain 
+   coordination.
 
-   Another solution could be to rely on the MDSC recursive hierarchy,
-   as defined in section 4.1 of {{!RFC8453}}, where, for each IP and
-   optical domain pair, a "lower-level MDSC" (MDSC-L) provides the
-   essential multi-layer correlation and the "higher-level MDSC"
-   (MDSC-H) provides the multi-domain coordination.
-   In this case, the MDSC-H can get an abstract view of the
-   underlying multi-layer domain topologies from its underlying MDSC-L. Each MDSC-L gets the full view of the IP domain topology from
-   P-PNC and can get an abstracted view of the optical domain
-   topology from its underlying O-PNC. In other words, topology
-   abstraction is possible at the MPIs between MDSC-L and O-PNC and
-   between MDSC-L and MDSC-H.
+   In this case, the MDSC-H obtains an abstract view of the underlying 
+   multi-layer domain topologies from its MDSC-L. Each MDSC-L gets the 
+   full IP domain topology from the P-PNC and an abstracted view of the 
+   optical domain topology from its O-PNC. Topology abstraction occurs 
+   at the MPIs between MDSC-L and O-PNC, as well as between MDSC-L and 
+   MDSC-H.
 
 1. Partial summarization: In this approach, the MDSC has complete
 visibility of the TE topology of the packet network domains and an
 abstracted view of the TE topology of the optical network domains.
 
-   The MDSC then has only the capability of performing multi-domain/single-layer path computation for the packet layer (the
-   path can be computed optimally for the two packet domains).
+   The MDSC can then only perform multi-domain/single-layer path 
+   computation for the packet layer, where the path can be computed 
+   optimally for the two packet domains.
 
-   Therefore, the MDSC still needs to delegate the O-PNCs to perform
-   local path computation within their respective domains. It uses
-   the information received by the O-PNCs and its TE topology view of
-   the multi-domain packet layer to perform multi-layer/multi-domain
-   path computation.
+   The MDSC still needs to delegate the O-PNCs to perform local path 
+   computation within their domains. It uses the information from the 
+   O-PNCs and its TE topology view of the multi-domain packet layer to 
+   perform multi-layer/multi-domain path computation.
 
 1. Full knowledge: In this approach, the MDSC has a complete and
 enough detailed view of the TE topology of all the network domains
 (both optical and packet).
 
-   In such case MDSC has all the information needed to perform multi-domain/multi-layer path computation, without relying on PNCs.
+   In such a case, the MDSC has all the information needed to perform
+   multi-domain/multi-layer path computation without relying on PNCs.
 
-   This approach may present, as a potential drawback, scalability
-   issues and, as discussed in section 2.2. of {{!I-D.ietf-teas-yang-path-computation}},
-   performing path computation for optical networks in the MDSC is
-   quite challenging because the optimal paths depend also on
-   vendor-specific optical attributes (which may be different in the
-   two domains if different vendors provide them).
+   This approach, however, may present scalability issues. As discussed
+in 
+   Section 2.2 of {{!I-D.ietf-teas-yang-path-computation}}, performing
+path 
+   computation for optical networks in the MDSC is particularly
+challenging, 
+   as optimal paths also depend on vendor-specific optical attributes, 
+   which may vary across domains if provided by different vendors.
 
-This document analyses scenarios where the MDSC uses the partial
-summarization approach to coordinate multi-domain/multi-layer path
+This document examines scenarios where the MDSC adopts the partial 
+summarization approach to enable multi-domain and multi-layer path 
 computation.
 
-Typically, the O-PNCs are responsible for the optical path
-computation of services across their respective single domains.
-Therefore, when setting up the network service, they must consider
-the connection requirements such as bandwidth, amplification,
-wavelength continuity, and non-linear impairments that may affect the
+Typically, O-PNCs are responsible for optical path computation within 
+their respective domains. When setting up a network service, they must 
+consider connection requirements such as bandwidth, amplification, 
+wavelength continuity, and non-linear impairments that may impact the 
 network service path.
 
-The methods and types of path requirements and impairments, such as
-those detailed in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}}, used by the O-PNC for optical path
-computation are not exposed at the MPI and therefore out of scope for
-this document.
+The methods and types of path requirements and impairments, such as 
+those detailed in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}}, 
+used by the O-PNC for optical path computation are not exposed at the 
+MPI and therefore out of scope for this document.
 
 {: #packet-pnc-overview}
 
 ## IP/MPLS Domain Controller and IP router Functions
 
-Each packet domain in {{fig-ref-network}}, corresponding to either an IGP area
-or an Autonomous System (AS) within the same operator network, is
-controlled by a packet domain controller (P-PNC).
+Each packet domain in {{fig-ref-network}}, corresponding to either an 
+IGP area or an Autonomous System (AS) within the same operator network, 
+is controlled by a packet domain controller (P-PNC).
 
-P-PNCs are responsible for setting up the TE paths between any two
-PEs or BRs in their respective controlled domains, as requested by
-MDSC,  and providing topology information to the MDSC.
+P-PNCs are responsible for establishing TE paths between any two PEs 
+or BRs within their controlled domains, as requested by the MDSC. They 
+also provide topology information to the MDSC to enable efficient 
+network coordination.
 
-For example, for inter-domain SR-TE, the setup bidirectional SR-TE
-path from PE13 in domain 1 to PE23 in domain 2, as shown in {{fig-vpn-path}},
-requires the MDSC to coordinate the actions of:
+For example, in inter-domain SR-TE, setting up a bidirectional 
+SR-TE path from PE13 in Domain 1 to PE23 in Domain 2, as shown in 
+{{fig-vpn-path}}, requires the MDSC to coordinate the following actions:
 
-- P-PNC1 to push a SID list to PE13 including the Binding SID
-associated to the SR-TE path in Domain 2 with PE23 as the target
-destination (forward direction);
+- P-PNC1: Push a SID list to PE13, including the Binding SID 
+  associated with the SR-TE path in Domain 2, with PE23 as the target 
+  destination (forward direction).
 
-- P-PNC2 to push a SID list to PE23, including the Binding SID
-associated with the SR-TE path in Domain 1 with PE13 as the target
-destination (reverse direction).
+- P-PNC2: Push a SID list to PE23, including the Binding SID 
+  associated with the SR-TE path in Domain 1, with PE13 as the target 
+  destination (reverse direction).
 
-With reference to {{fig-p-pnc}}, P-PNCs are then responsible:
+With reference to {{fig-p-pnc}}, P-PNCs are responsible for the 
+following:
 
 1. To expose to MDSC their respective detailed TE topology
 
-1. To perform single-layer single-domain local TE path computation,
-when requested by MDSC between two PEs (for single-domain end-to-end TE path) or between PEs and BRs for an inter-domain TE path
-selected by MDSC;
+1. To perform single-layer, single-domain local TE path computation, 
+when requested by the MDSC, between two PEs (for single-domain 
+end-to-end TE path) or between PEs and BRs for an inter-domain TE 
+path selected by the MDSC.
 
 1. To configure the routers in their respective domain to setup a TE
 path;
 
-1. To configure the VRF and PE-CE interfaces (Service access points)
-of the intra-domain and inter-domain network services requested by
+1. To configure the VRF and PE-CE interfaces (Service access points) 
+for the intra-domain and inter-domain network services requested by 
 the MDSC.
 
 ~~~~ ascii-art
@@ -710,10 +750,11 @@ the MDSC.
 ~~~~
 {: #fig-p-pnc title="Domain Controller & node Functions"}
 
-When requesting the setup of a new TE path, the MDSC provides the P-PNCs with the explicit path to be created or modified. In other
-words, the MDSC can communicate to the P-PNCs the complete list of
-nodes involved in the path (strict mode). In this case, the P-PNC is
-just responsible to set up that explicit TE path. For example:
+When requesting a new TE path setup, the MDSC provides the P-PNCs 
+with the explicit path to be created or modified. In other words, the 
+MDSC communicates the complete list of nodes involved in the path 
+(strict mode). The P-PNC is then responsible for setting up the 
+explicit TE path. For example:
 
 - with SR-TE, the P-PNC pushes to headend PE or BR the list of SIDs
 to create the explicit SR-TE path, provided by the MDSC;
@@ -721,114 +762,116 @@ to create the explicit SR-TE path, provided by the MDSC;
 - with RSVP-TE, the P-PNC requests the headend PE or BR to start
 signaling the explicit RSVP-TE path, provided by the MDSC.
 
-To scale in large SR-TE packet domains, the MDSC can provide P-PNC a
-loose path, together with per-domain TE constraints. The P-PNC can
-then select the complete path within its domain.
+To scale in large SR-TE packet domains, the MDSC can provide the P-PNC 
+with a loose path and per-domain TE constraints. The P-PNC can then 
+select the complete path within its domain.
 
-In such a case, it is mandatory that P-PNC signals back to the MDSC
-which path it has chosen so that the MDSC keeps track of the relevant
-resources utilization.
+In this case, it is mandatory for the P-PNC to signal back to the MDSC 
+which path it has chosen, allowing the MDSC to track relevant 
+resource utilization.
 
-From the {{fig-vpn-path}} example, the TE path requested by the MDSC touches
-PE13 - P16 - BR12 - BR21 - PE23. P-PNC2 is aware of two paths with
-the same topology metric, e.g. BR21 - P24 - PE23 and BR21 - BR22 - PE23, but with different loads. It may prefer to steer the traffic on
-the latter because it is less loaded.
+From the {{fig-vpn-path}} example, the TE path requested by the MDSC 
+touches PE13 - P16 - BR12 - BR21 - PE23. P-PNC2 is aware of two 
+paths with the same topology metric, e.g., BR21 - P24 - PE23 and 
+BR21 - BR22 - PE23, but with different loads. It may prefer to steer 
+traffic on the latter as it is less loaded.
 
-For the purposes of this document it is assumed that the MDSC always
-provides the explicit list of all the hops to the P-PNCs to setup or
+For the purposes of this document, it is assumed that the MDSC always 
+provides the explicit list of all hops to the P-PNCs to set up or 
 modify the TE path.
 
 {: #optical-pnc-overview}
 
 ## Optical Domain Controller and NE Functions
 
-The optical network provides underlay connectivity services to
-IP/MPLS networks. The packet and optical multi-layer coordination is
-done by the MDSC, as shown in {{fig-ref-network}}.
+The optical network provides underlay connectivity services to 
+IP/MPLS networks. The packet and optical multi-layer coordination 
+is handled by the MDSC, as shown in {{fig-ref-network}}.
 
 The O-PNC is responsible to:
 
-- provide to the MDSC an abstract TE topology view of its underlying
-optical network resources;
+- Provide the MDSC with an abstract TE topology view of its underlying 
+  optical network resources;
 
-- perform single-domain local path computation, when requested by
-the MDSC;
+- perform single-domain local path computation when requested by 
+  the MDSC;
 
-- perform optical tunnel setup, when requested by the MDSC.
+- Perform optical tunnel set up when requested by the MDSC.
 
-The mechanisms used by O-PNC to perform intra-domain topology
-discovery and path setup are usually vendor-specific and outside the
-scope of this document.
+The mechanisms used by the O-PNC to perform intra-domain topology 
+discovery and path setup are typically vendor-specific and outside 
+the scope of this document.
 
-Depending on the type of optical network, TE topology abstraction,
-path computation and path setup can be single-layer (either OTN or
-WDM) or multi-layer OTN/WDM. In the latter case, the multi-layer
-coordination between the OTN and WDM layers is performed by the
-O-PNC.
+Depending on the optical network type, TE topology abstraction, path 
+computation, and path setup can be single-layer (either OTN or WDM) 
+or multi-layer OTN/WDM. In the latter case, multi-layer coordination 
+between the OTN and WDM layers is handled by the O-PNC.
 
 {: #mpi}
 
 # Interface Protocols and YANG Data Models for the MPIs
 
-This section describes general assumptions applicable to all the MPI
-interfaces, between each PNC (Optical or Packet) and the MDSC, to
+This section describes general assumptions applicable to all MPI 
+interfaces between each PNC (Optical or Packet) and the MDSC, to 
 support the scenarios discussed in this document.
 
 {: #restconf}
 
 ## RESTCONF Protocol at the MPIs
 
-The RESTCONF protocol, as defined in {{!RFC8040}}, using the JSON
-representation defined in {{!RFC7951}}, is assumed to be used at these
-interfaces. In addition, extensions to RESTCONF, as defined in
-{{!RFC8527}}, to be compliant with Network Management Datastore
-Architecture (NMDA) defined in {{!RFC8342}}, are assumed to be used as
-well at these MPI interfaces and also at MDSC NBI interfaces.
+The RESTCONF protocol, as defined in {{!RFC8040}}, using the JSON 
+representation from {{!RFC7951}}, is assumed to be used at these 
+interfaces. Additionally, extensions to RESTCONF, as defined in 
+{{!RFC8527}}, to comply with the Network Management Datastore 
+Architecture (NMDA) from {{!RFC8342}}, are assumed to be used at 
+these MPI and MDSC NBI interfaces.
 
 {: #yang}
 
 ## YANG Data Models at the MPIs
 
-The data models used on these interfaces are assumed to use the YANG
+The data models used on these interfaces are assumed to use the YANG 
 1.1 Data Modeling Language, as defined in {{!RFC7950}}.
 
-This section describes the YANG data models that are applicable to
-the Packet and Optical MPIs. Some of these YANG data models can be
-optional depending on the specific network configuration detailed
-in {{discovery}} and {{config}}.
+This section describes the YANG data models applicable to the Packet 
+and Optical MPIs. Some of these YANG data models may be optional, 
+depending on the specific network configuration detailed in 
+{{discovery}} and {{config}}.
 
 {: #common-yang}
 
 ### Common YANG Data Models at the MPIs
 
-As required in {{!RFC8040}}, the "ietf-yang-library" YANG module defined
-in {{!RFC8525}} is used to allow the MDSC to discover the set of YANG
-modules supported by each PNC at its MPI.
+As required in {{!RFC8040}}, the "ietf-yang-library" YANG module 
+defined in {{!RFC8525}} is used to allow the MDSC to discover the 
+set of YANG modules supported by each PNC at its MPI.
 
-Both Optical and Packet PNCs can use the following common topology
+Both Optical and Packet PNCs can use the following common topology 
 YANG data models at the MPI:
 
 - The Base Network Model, defined in the "ietf-network" YANG module
 of {{!RFC8345}};
 
-- The Base Network Topology Model, defined in the "ietf-network-topology" YANG module of {{!RFC8345}}, which augments the Base Network Model;
+- The Base Network Topology Model, defined in the "ietf-network-topology"
+YANG module of {{!RFC8345}}, which augments the Base Network Model;
 
 - The TE Topology Model, defined in the "ietf-te-topology" YANG
 module of {{!RFC8795}}, which augments the Base Network Topology
 Model.
 
-Optical and Packet PNCs can use the common TE Tunnel Model, defined
+Optical and Packet PNCs can use the common TE Tunnel Model, defined 
 in the "ietf-te" YANG module of {{!I-D.ietf-teas-yang-te}}, at the MPI.
 
-All the common YANG data models are generic and augmented by
-technology-specific YANG modules, as described in the following
+All common YANG data models are generic and augmented by 
+technology-specific YANG modules, as described in the following 
 sections.
 
-Both Optical and Packet PNCs can also use the Ethernet Topology
-Model, defined in the "ietf-eth-te-topology" YANG module of {{!I-D.ietf-ccamp-eth-client-te-topo-yang}},
-which augments the TE Topology Model with Ethernet technology-specific information.
+Both Optical and Packet PNCs can also use the Ethernet Topology 
+Model, defined in the "ietf-eth-te-topology" YANG module of 
+{{!I-D.ietf-ccamp-eth-client-te-topo-yang}}, which augments the TE 
+Topology Model with Ethernet technology-specific information.
 
-Both Optical and Packet PNCs can use the following common
+Both Optical and Packet PNCs can use the following common 
 notifications YANG data models at the MPI:
 
 - Dynamic Subscription to YANG Events and Datastores over RESTCONF
@@ -844,13 +887,15 @@ PNCs and MDSCs comply with subscription requirements as stated in
 
 ### YANG models at the Optical MPIs
 
-The Optical PNC can use the following technology-specific topology
+The Optical PNC can use the following technology-specific topology 
 YANG data models, which augment the generic TE Topology Model:
 
 - The WSON Topology Model, defined in the "ietf-wson-topology" YANG
 module of {{!RFC9094}};
 
-- the Flexi-grid Topology Model, defined in the "ietf-flexi-grid-topology" YANG module of {{!I-D.ietf-ccamp-flexigrid-yang}};
+- the Flexi-grid Topology Model, defined in the
+"ietf-flexi-grid-topology" YANG module of
+{{!I-D.ietf-ccamp-flexigrid-yang}};
 
 - the OTN Topology Model, as defined in the "ietf-otn-topology" YANG
 module of {{!I-D.ietf-ccamp-otn-topo-yang}}.
@@ -868,16 +913,18 @@ The optical PNC can use the generic Path Computation YANG RPC,
 defined in the "ietf-te-path-computation" YANG module of
 {{!I-D.ietf-teas-yang-path-computation}}.
 
-Note that technology-specific augmentations of the generic path
-computation RPC for WSON, Flexi-grid and OTN path computation RPCs
+Note that technology-specific augmentations of the generic path 
+computation RPC for WSON, Flexi-grid, and OTN path computation RPCs 
 have been identified as a gap.
 
-The optical PNC uses can use the following client signal YANG data
-models:
+The optical PNC can use the following client signal YANG data models:
 
-- the CBR Client Signal Model, defined in the "ietf-trans-client-service" YANG module of {{!I-D.ietf-ccamp-client-signal-yang}};
+- the CBR Client Signal Model, defined in the "ietf-trans-client-service"
+YANG module of {{!I-D.ietf-ccamp-client-signal-yang}};
 
-- the Ethernet Client Signal Model, defined in the "ietf-eth-tran-service" YANG module of {{!I-D.ietf-ccamp-client-signal-yang}}.
+- the Ethernet Client Signal Model, defined in the
+"ietf-eth-tran-service" YANG module of
+{{!I-D.ietf-ccamp-client-signal-yang}}.
 
 {: #packet-yang}
 
@@ -890,13 +937,17 @@ YANG data models:
 YANG module of {{!RFC8346}}, which augments the Base Network Topology
 Model;
 
-- the Packet TE Topology Mode, defined in the "ietf-te-topology-packet" YANG module of {{!I-D.ietf-teas-yang-l3-te-topo}}, which augments the generic TE
+- the Packet TE Topology Mode, defined in the "ietf-te-topology-packet"
+YANG module of {{!I-D.ietf-teas-yang-l3-te-topo}}, which augments the
+generic TE
 Topology Model;
 
 - The MPLS-TE Topology Model, defined in the "ietf-te-mpls-topology"
-YANG module of {{!I-D.ietf-teas-yang-te-mpls-topology}}, which augments the TE Packet
+YANG module of {{!I-D.ietf-teas-yang-te-mpls-topology}}, which augments
+the TE Packet
 Topology Model with or without the L3 TE Topology Model, defined
-in "ietf-l3-te-topology" YANG module of {{!I-D.ietf-teas-yang-l3-te-topo}};
+in "ietf-l3-te-topology" YANG module of
+{{!I-D.ietf-teas-yang-l3-te-topo}};
 
 - the SR Topology Model, defined in the "ietf-sr-mpls-topology" YANG
 module of {{!I-D.ietf-teas-yang-sr-te-topo}}.
@@ -916,44 +967,46 @@ models:
 - L3VPN Network Model (L3NM), defined in the "ietf-l3vpn-ntw" YANG
 module of {{?RFC9182}};
 
-- L3NM TE Service Mapping, defined in the "ietf-l3nm-te-service-mapping" YANG module of {{?I-D.ietf-teas-te-service-mapping-yang}};
+- L3NM TE Service Mapping, defined in the "ietf-l3nm-te-service-mapping"
+YANG module of {{?I-D.ietf-teas-te-service-mapping-yang}};
 
 - L2VPN Network Model (L2NM), defined in the "ietf-l2vpn-ntw" YANG
 module of {{?RFC9291}};
 
-- L2NM TE Service Mapping, defined in the "ietf-l2nm-te-service-mapping" YANG module of {{?I-D.ietf-teas-te-service-mapping-yang}}.
+- L2NM TE Service Mapping, defined in the "ietf-l2nm-te-service-mapping"
+YANG module of {{?I-D.ietf-teas-te-service-mapping-yang}}.
 
 {: #pcep}
 
 ## Path Computation Element Protocol (PCEP)
 
-{{?RFC8637}} examines the applicability of a Path Computation Element
-(PCE) {{?RFC5440}} and PCE Communication Protocol (PCEP) to the ACTN
-framework. It further describes how the PCE architecture applies to
-ACTN and lists the PCEP extensions needed to use PCEP as an ACTN
-interface.  The stateful PCE {{?RFC8231}}, PCE-Initiation {{?RFC8281}},
-stateful Hierarchical PCE (H-PCE) {{?RFC8751}}, and PCE as a central
-controller (PCECC) {{?RFC8283}} are some of the key extensions that
-enable the use of PCE/PCEP for ACTN.
+{{?RFC8637}} examines the applicability of a Path Computation Element 
+(PCE) {{?RFC5440}} and PCE Communication Protocol (PCEP) to the ACTN 
+framework. It further describes how the PCE architecture applies to 
+ACTN and lists the PCEP extensions needed to use PCEP as an ACTN 
+interface. The stateful PCE {{?RFC8231}}, PCE-Initiation {{?RFC8281}}, 
+stateful Hierarchical PCE (H-PCE) {{?RFC8751}}, and PCE as a central 
+controller (PCECC) {{?RFC8283}} are key extensions enabling the use of 
+PCE/PCEP for ACTN.
 
-Since the PCEP supports path computation in the packet and optical
-networks, PCEP is well suited for inter-layer path computation.
-{{?RFC5623}} describes a framework for applying the PCE-based
-architecture to interlayer (G)MPLS traffic engineering. Furthermore,
-section 6.1 of {{?RFC8751}} states the H-PCE applicability for inter-layer or POI.
+Since PCEP supports path computation in both packet and optical 
+networks, it is well-suited for inter-layer path computation. 
+{{?RFC5623}} describes a framework for applying the PCE-based 
+architecture to interlayer (G)MPLS traffic engineering. Furthermore, 
+section 6.1 of {{?RFC8751}} outlines H-PCE applicability for 
+inter-layer or POI.
 
 {{?RFC8637}} lists various PCEP extensions that apply to ACTN. It also
 lists the PCEP extension for the optical network and POI.
 
-Note that the PCEP can be used in conjunction with the YANG data
-models described in the rest of this document. Depending on whether
-ACTN is deployed in a greenfield or brownfield, two options are
-possible:
+Note that PCEP can be used in conjunction with the YANG data models 
+described in the rest of this document. Depending on whether ACTN is 
+deployed in a greenfield or brownfield, two options are possible:
 
-1. The MDSC uses a single RESTCONF/YANG interface towards each PNC to
-discover all the TE information and request TE tunnels. It may
-perform full multi-layer path computation or delegate path
-computation to the underneath PNCs.
+1. The MDSC uses a single RESTCONF/YANG interface to each PNC to 
+discover all TE information and request TE tunnels. It may perform 
+full multi-layer path computation or delegate path computation to 
+the underlying PNCs.
 
    This approach is desirable for operators from a multi-vendor
    integration perspective as it is simple. We need only one type of
@@ -971,7 +1024,8 @@ tunnels. However, it uses PCEP for hierarchical path computation.
    instead of one unless the RESTCONF/YANG interface is added to an
    existing PCEP deployment (brownfield scenario).
 
-{{discovery}} and {{config}} of this draft analyze the case where a single
+{{discovery}} and {{config}} of this draft analyze the case where a
+single
 RESTCONF/YANG interface is deployed at the MPI (i.e., option 1
 above).
 
@@ -1014,7 +1068,8 @@ this approach and mechanisms to address potential issues is outside
 the scope of this document.
 
 Each PNC provides the MDSC the topology view of the domain it
-controls, as described in {{optical-topology-discovery}} and {{packet-topology-discovery}}. The MDSC uses this
+controls, as described in {{optical-topology-discovery}} and
+{{packet-topology-discovery}}. The MDSC uses this
 information to discover the complete topology view of the multi-layer
 multi-domain networks it controls.
 
@@ -1027,7 +1082,8 @@ It should also be possible to correlate information from IP and
 optical layers (e.g., which port, lambda/OTSi, and direction are used
 by a specific IP service on the WDM equipment).
 
-In particular, for the cross-technology Ethernet links, it is key for MDSC to
+In particular, for the cross-technology Ethernet links, it is key for
+MDSC to
 automatically correlate the information from the PNC network
 databases about the physical ports from the routers (single link or
 bundle links for LAG) to client ports in the ROADM.
@@ -1071,14 +1127,16 @@ reported using either the Flexi-grid Topology model or both WSON
 and Flexi-grid topology models.
 
 Clarifying how both WSON and Flexi-grid topology models could be used
-together (e.g., through multi-inheritance as described in {{?I-D.ietf-teas-te-topology-profiles}})
+together (e.g., through multi-inheritance as described in
+{{?I-D.ietf-teas-te-topology-profiles}})
 has been identified as a gap.
 
 The OTN Topology Model is used to report the OTN network topology
 (e.g., OTN switching nodes and links), when the OTN switching layer
 is deployed within the optical domain.
 
-To allow the MDSC to discover the complete multi-layer and multi-domain network topology and to correlate it with the hardware
+To allow the MDSC to discover the complete multi-layer and multi-domain
+network topology and to correlate it with the hardware
 inventory information, the O-PNCs report an abstract optical network
 topology where:
 
@@ -1088,11 +1146,13 @@ optical network domain; and
 - one TE link is reported for each OMS link and, optionally, for
 each OTN link.
 
-Since the MDSC delegates optical path computation to its underlay O-PNCs, the following information can be abstracted and not reported at
+Since the MDSC delegates optical path computation to its underlay O-PNCs,
+the following information can be abstracted and not reported at
 the MPI:
 
 - the optical parameters required for optical path computation, such
-as those detailed in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}};
+as those detailed in
+{{?I-D.ietf-ccamp-optical-impairment-topology-yang}};
 
 - the underlay OTS links and ILAs of OMS links;
 
@@ -1100,13 +1160,16 @@ as those detailed in {{?I-D.ietf-ccamp-optical-impairment-topology-yang}};
 ROADMs.
 
 The OTN Topology Model also reports the CBR client LTPs that
-terminates the cross-technology Ethernet links: once CBR client LTP is reported for
+terminates the cross-technology Ethernet links: once CBR client LTP is
+reported for
 each CBR or multi-function client interface on the optical nodes (see
-sections 4.4 and 5.1 of {{?I-D.ietf-ccamp-transport-nbi-app-statement}} for the description of multi-function
+sections 4.4 and 5.1 of {{?I-D.ietf-ccamp-transport-nbi-app-statement}}
+for the description of multi-function
 client interfaces).
 
 The Ethernet Topology Model reports the Ethernet client LTPs that
-terminate the cross-technology Ethernet links: one Ethernet client LTP is reported
+terminate the cross-technology Ethernet links: one Ethernet client LTP is
+reported
 for each Ethernet or multi-function client interface on the optical
 nodes.
 
@@ -1117,13 +1180,16 @@ abstraction is valid independently of the fact that optical
 transponders are physically integrated within the same WDM node or
 are physically located on a device external to the WDM node since it
 both cases the optical transponders and the WDM node are under the
-control of the same O-PNC and abstracted as a single WDM TE Node at the O-MPI.
+control of the same O-PNC and abstracted as a single WDM TE Node at the
+O-MPI.
 
 The association between the Ethernet or CBR client LTPs terminating
-the Ethernet cross-technology Ethernet links and the optical TTPs is reported using
+the Ethernet cross-technology Ethernet links and the optical TTPs is
+reported using
 the Inter Layer Lock-id (ILL) identifiers, defined in {{!RFC8795}}.
 
-For example, with a reference to {{fig-optical-topo}}, the ILL values X and Y are
+For example, with a reference to {{fig-optical-topo}}, the ILL values X
+and Y are
 used to associated the client LTPs (7-0) in NE11 and (8-0) in NE12
 with the corresponding optical TTPs (7) in NE11 and (8) in NE12,
 respectively.
@@ -1135,8 +1201,10 @@ The intra-domain optical links are discovered by O-PNCs, using
 mechanisms which are outside the scope of this document, and reported
 at the MPIs within the optical network topology.
 
-In case of a multi-layer DWDM/OTN network domain, multi-layer intra-domain OTN links are supported by underlay WDM tunnels: this
-relationship is reported by the mechanisms described in {{optical-path-discovery}}.
+In case of a multi-layer DWDM/OTN network domain, multi-layer
+intra-domain OTN links are supported by underlay WDM tunnels: this
+relationship is reported by the mechanisms described in
+{{optical-path-discovery}}.
 
 {: #optical-path-discovery}
 
@@ -1152,13 +1220,15 @@ established within the optical network.
 The Ethernet client signal model and the Transparent CBR client
 signal model are used to report all the connectivity services
 provided by the underlay optical tunnels between Ethernet or CBR
-client LTPs, depending on whether the connectivity service is frame-based or transparent. The underlay optical tunnels can be either WDM
+client LTPs, depending on whether the connectivity service is frame-based
+or transparent. The underlay optical tunnels can be either WDM
 tunnels or, when the optional OTN switching layer is deployed, OTN
 tunnels.
 
 The WDM tunnels can be used to support either Ethernet or CBR client
 signals or multi-layer intra-domain OTN links. In the latter case,
-the hierarchical-link container, defined in {{!I-D.ietf-teas-yang-te}}, associates
+the hierarchical-link container, defined in {{!I-D.ietf-teas-yang-te}},
+associates
 the underlay WDM tunnel with the supported multi-layer intra-domain
 OTN link and it allows discovery of the multi-layer path supporting
 all the connectivity services provided by the optical network.
@@ -1166,7 +1236,8 @@ all the connectivity services provided by the optical network.
 The O-PNCs report in their operational datastores all the Ethernet
 and CBR client connectivities and all the optical tunnels deployed
 within their optical domain regardless of the mechanisms being used to
-set them up, such as the mechanisms described in {{multi-technology-link-setup}}, as well
+set them up, such as the mechanisms described in
+{{multi-technology-link-setup}}, as well
 as other mechanism (e.g., static configuration), which are outside
 the scope of this document.
 
@@ -1178,19 +1249,22 @@ The L3 Topology Model is used report the IP network topology.
 
 The L3 Topology Model, SR Topology Model, TE Topology Model and the
 TE Packet Topology Model are used together to report the SR-TE
-network topology, as described in Figure 2 of {{!I-D.ietf-teas-yang-sr-te-topo}}.
+network topology, as described in Figure 2 of
+{{!I-D.ietf-teas-yang-sr-te-topo}}.
 
 The TE Topology Model, TE Packet Topology Model and MPLS-TE Topology
 Model are used together to report the MPLS-TE network topology, as
 described in {{!I-D.ietf-teas-yang-te-mpls-topology}}.
 
-As described in {{!I-D.ietf-teas-yang-l3-te-topo}}, the relationship between the IP network
+As described in {{!I-D.ietf-teas-yang-l3-te-topo}}, the relationship
+between the IP network
 topology and the MPLS-TE network topology depends on whether the two
 network topologies are congruent or not: in the latter case, the L3
 TE Topology Model is used, together with the L3 Topology Model to
 provide the association between the two network topologies.
 
-To allow the MDSC to discover the complete multi-layer and multi-domain network topology and to correlate it with the hardware
+To allow the MDSC to discover the complete multi-layer and multi-domain
+network topology and to correlate it with the hardware
 inventory information as well as to perform multi-domain TE path
 computation, the P-PNCs report the full packet network, including all
 the information that the MDSC requires to perform TE path
@@ -1201,8 +1275,10 @@ links.
 
 The Ethernet Topology Model is used to report the intra-domain
 Ethernet links supporting the intra-domain IP links as well as the
-Ethernet LTPs that might terminate cross-technology Ethernet links, inter-domain
-Ethernet links or access links, as described in detail in {{inter-domain-link-discovery}}
+Ethernet LTPs that might terminate cross-technology Ethernet links,
+inter-domain
+Ethernet links or access links, as described in detail in
+{{inter-domain-link-discovery}}
 and in {{multi-technology-link-discovery}}.
 
 All the intra-domain Ethernet and IP links are discovered by the
@@ -1216,20 +1292,24 @@ the Ethernet or the packet network topology.
 
 We assume that the discovery of existing TE paths, including their
 bandwidth, at the MPI is done using the generic TE tunnel YANG data
-model, defined in {{!I-D.ietf-teas-yang-te}}, with packet technology-specific (e.g.,
+model, defined in {{!I-D.ietf-teas-yang-te}}, with packet
+technology-specific (e.g.,
 MPLS-TE or SR-TE) augmentations.
 
 Note that technology-specific augmentations of the generic path TE
 tunnel model for SR-TE path setup and discovery is outlined in
-section 1 of {{!I-D.ietf-teas-yang-te}} but are currently identified as a gap in
+section 1 of {{!I-D.ietf-teas-yang-te}} but are currently identified as a
+gap in
 {{conclusions}}.
 
 To enable MDSC to discover the full end-to-end TE path configuration,
-the technology-specific augmentation of the {{!I-D.ietf-teas-yang-te}} should allow
+the technology-specific augmentation of the {{!I-D.ietf-teas-yang-te}}
+should allow
 the P-PNC to report the TE path within its domain (e.g., the SID list
 assigned to an SR-TE path).
 
-For example, considering the L3VPN in {{fig-vpn-topo}}, the TE path 1 in one
+For example, considering the L3VPN in {{fig-vpn-topo}}, the TE path 1 in
+one
 direction (PE13-P16-PE14) and the TE path in the reverse direction
 (between PE14 and PE13) should be reported by the P-PNC1 to the MDSC
 as TE primary and primary-reverse paths of the same TE tunnel
@@ -1254,7 +1334,8 @@ inter-domain links:
 - Inter-domain Ethernet links supporting inter-domain IP links
 between two adjacent IP domains;
 
-- Cross-technology Ethernet links between an an IP domain and an adjacent optical
+- Cross-technology Ethernet links between an an IP domain and an adjacent
+optical
 domain;
 
 - Access links between a CE device and a PE router.
@@ -1262,7 +1343,8 @@ domain;
 All the three types of links are Ethernet links.
 
 It is worth noting that the P-PNC may not be aware whether an
-Ethernet interface terminates a cross-technology Ethernet link, an inter-domain
+Ethernet interface terminates a cross-technology Ethernet link, an
+inter-domain
 Ethernet link or an access link. The TE Topology Model supports the
 discovery for all these types of links with no need for the P-PNC to
 know the type of inter-domain link.
@@ -1275,12 +1357,14 @@ Although the discovery of access links is outside the scope of this
 document, clarifying the relationship between these two models has
 been identified as a gap.
 
-The inter-domain Ethernet links and cross-technology Ethernet links are discovered
+The inter-domain Ethernet links and cross-technology Ethernet links are
+discovered
 by the MDSC using the plug-id attribute, as described in section 4.3
 of {{!RFC8795}}.
 
 More detailed description of how the plug-id can be used to discover
-inter-domain links is also provided in section 5.1.4 of {{?I-D.ietf-ccamp-transport-nbi-app-statement}}.
+inter-domain links is also provided in section 5.1.4 of
+{{?I-D.ietf-ccamp-transport-nbi-app-statement}}.
 
 The plug-id attribute can also be used to discover the access-links,
 but the analysis of the access-link discovery is outside the scope of
@@ -1293,152 +1377,180 @@ inter-domain links:
 
 2. LLDP {{IEEE_802.1AB}} automatic discovery
 
-Other options are possible but not described in this document.
+Other link discovery options are possible but not described in this 
+document.
 
-As outlined in {{?I-D.ietf-ccamp-transport-nbi-app-statement}}, the encoding of the plug-id namespace and the
-specific LLDP information reported within the plug-id value, such as
-the Chassis ID and Port ID mandatory TLVs, is implementation specific
-and needs to be consistent across all the PNCs within the network.
+As outlined in {{?I-D.ietf-ccamp-transport-nbi-app-statement}}, the 
+encoding of the plug-id namespace and the specific LLDP information 
+reported within the plug-id value, such as the Chassis ID and Port ID 
+mandatory TLVs, is implementation-specific and needs to be consistent 
+across all PNCs within the network.
 
-The static configuration requires an administrative burden to
-configure network-wide unique identifiers: it is therefore more
-viable for inter-domain Ethernet links. For the cross-technology Ethernet links, the
-automatic discovery solution based on LLDP snooping is preferable
-when possible.
+The static configuration requires an administrative burden to 
+configure network-wide unique identifiers, making it more viable for 
+inter-domain Ethernet links. For cross-technology Ethernet links, the 
+automatic discovery solution based on LLDP snooping is preferable when 
+possible.
 
-The routers exchange standard LLDP packets as defined in {{IEEE_802.1AB}}
-and the optical nodes snoop the LLDP packets received from the
-local Ethernet interface and report to the O-PNCs the extracted
-information, such as the Chassis ID, the Port ID, System Name TLVs.
+The routers exchange standard LLDP packets as defined in {{IEEE_802.1AB}}, 
+and the optical nodes snoop the LLDP packets received from the local 
+Ethernet interface and report the extracted information, such as the 
+Chassis ID, Port ID, and System Name TLVs, to the O-PNCs.
 
-Note that the optical nodes do not actively participate in the LLDP
-packet exchange and does not send any LLDP packets.
+Note that the optical nodes do not actively participate in the LLDP 
+packet exchange and do not send any LLDP packets.
 
-### Cross-technology Ethernet link Discovery {#cross-technology-link-discovery}
+### Cross-technology Ethernet link Discovery
+{#cross-technology-link-discovery}
 
-The MDSC can discover a cross-technology Ethernet link by matching the plug-id
-values of the two LTPs reported by two adjacent O-PNC and P-PNC: in
-case LLDP snooping is used, the P-PNC reports the LLDP information
-sent by the corresponding Ethernet interface on the IP router while the
-O-PNC reports the LLDP information received by the corresponding
-Ethernet interface on the optical node, e.g., between LTP 5-0 on PE13
-and LTP 7-0 on NE11, as shown in {{fig-cross-technology-link}}.
+The MDSC can discover a cross-technology Ethernet link by matching 
+the plug-id values of the two LTPs reported by adjacent O-PNC and 
+P-PNCs. In case LLDP snooping is used, the P-PNC reports the LLDP 
+information sent by the corresponding Ethernet interface on the IP 
+router, while the O-PNC reports the LLDP information received by the 
+corresponding Ethernet interface on the optical node, e.g., between 
+LTP 5-0 on PE13 and LTP 7-0 on NE11, as shown in 
+{{fig-cross-technology-link}}.
 
 {::include ./figures/cross-technology-link.md}
-{: #fig-cross-technology-link title="Cross-technology Ethernet link discovery"}
+{: #fig-cross-technology-link title="Cross-technology Ethernet link
+discovery"}
 
-As described in {{optical-topology-discovery}}, the LTP terminating a cross-technology Ethernet link
-is reported by an O-PNC in the Ethernet topology or in the OTN
-topology model or in both models, depending on the type of
-corresponding physical port on the optical node.
+As described in {{optical-topology-discovery}}, the LTP terminating 
+a cross-technology Ethernet link is reported by an O-PNC in the 
+Ethernet topology, the OTN topology model, or both, depending on the 
+type of corresponding physical port on the optical node.
 
-It is worth noting that the discovery of cross-technology Ethernet links is based
-only on the LLDP information sent by the Ethernet interfaces of the
-routers and snooped by the Ethernet interfaces of the optical nodes.
-Therefore the MDSC can discover these links also before optical
-paths, supporting overlay multi-technology IP links, are setup.
+It is worth noting that the discovery of cross-technology Ethernet 
+links is based solely on the LLDP information sent by the Ethernet 
+interfaces of the routers and snooped by the Ethernet interfaces of 
+the optical nodes. Therefore, the MDSC can discover these links even 
+before optical paths, supporting overlay multi-technology IP links, 
+are set up.
 
 {: #ip-inter-domain-link-discovery}
 
 ### Inter-domain IP Link Discovery
 
-The MDSC can discover an inter-domain Ethernet link which supports an
-inter-domain IP link, by matching the plug-id values of the two
-Ethernet LTPs reported by the two adjacent P-PNCs: the two P-PNCs
-report the LLDP information being sent and being received from the
-corresponding Ethernet interfaces, e.g., between the Ethernet LTP 3-1
-on BR11 and the Ethernet LTP 4-1 on BR21 shown in {{fig-inter-domain-link}}.
+The MDSC can discover an inter-domain Ethernet link supporting an 
+inter-domain IP link by matching the plug-id values of the two 
+Ethernet LTPs reported by adjacent P-PNCs. The P-PNCs report the 
+LLDP information being sent and received from the corresponding 
+Ethernet interfaces, e.g., between Ethernet LTP 3-1 on BR11 and 
+Ethernet LTP 4-1 on BR21, as shown in {{fig-inter-domain-link}}.
 
 {::include ./figures/inter-domain-link.md}
-{: #fig-inter-domain-link title="Inter-domain Ethernet and IP link discovery"}
+{: #fig-inter-domain-link title="Inter-domain Ethernet and IP link
+discovery"}
 
 Different information is required to be encoded by the P-PNC within
-the plug-id attribute of the Ethernet LTPs to discover cross-technology Ethernet
+the plug-id attribute of the Ethernet LTPs to discover cross-technology
+Ethernet
 links and inter-domain Ethernet links.
 
-If the P-PNC does not know a priori whether an Ethernet interface on
-an IP router terminates a cross-technology Ethernet link or an inter-domain Ethernet
-link, it has to report at the MPI two Ethernet LTPs representing the
-same Ethernet interface, e.g., both the Ethernet LTP 3-0 and the
-Ethernet LTP 3-1, supported by LTP 3-0, shown in {{fig-inter-domain-link}}:
+If the P-PNC does not know a priori whether an Ethernet interface 
+on an IP router terminates a cross-technology Ethernet link or an 
+inter-domain Ethernet link, it must report at the MPI two Ethernet 
+LTPs representing the same Ethernet interface, e.g., both Ethernet 
+LTP 3-0 and Ethernet LTP 3-1, supported by LTP 3-0, as shown in 
+{{fig-inter-domain-link}}.
 
-- The physical Ethernet LTP (e.g., LTP 3-0 in BR11, as shown in
-{{fig-inter-domain-link}}) is used to represent the physical adjacency between the
-Ethernet interface on an IP router and the Ethernet interface on its physically adjacent node,
-which can be either an IP router
-(in case of a single-technology Ethernet link) or an optical
-node (in case of a cross-technology Ethernet link).
-Therefore, as described in {{cross-technology-link-discovery}}, the P-PNC reports,
-within the plug-id attribute of this LTP, the LLDP information
-sent by the corresponding Ethernet interface on the IP router; such as the
-{BR11,3} and {BR21,4} plug-id values reported, respectively, by
-the Ethernet LTP 3-0 on BR11 and by the Ethernet LTP 4-0 on BR21,
-as shown in {{fig-inter-domain-link}};
+- The physical Ethernet LTP (e.g., LTP 3-0 in BR11, as shown in 
+{{fig-inter-domain-link}}) represents the physical adjacency between 
+the Ethernet interface on an IP router and the Ethernet interface on 
+its physically adjacent node. This node can be either an IP router 
+(in the case of a single-technology Ethernet link) or an optical node 
+(in the case of a cross-technology Ethernet link). Therefore, as 
+described in {{cross-technology-link-discovery}}, the P-PNC reports, 
+within the plug-id attribute of this LTP, the LLDP information sent 
+by the corresponding Ethernet interface on the IP router, such as 
+{BR11,3} and {BR21,4} plug-id values reported by the Ethernet LTP 
+3-0 on BR11 and the Ethernet LTP 4-0 on BR21, as shown in 
+{{fig-inter-domain-link}}.
 
-- The logical Ethernet LTP (e.g., LTP 3-1 in BR11, as shown in
-{{fig-inter-domain-link}}), supported by a physical Ethernet LTP (e.g., LTP 3-0 in
-BR11, as shown in {{fig-inter-domain-link}}), is used to discover the logical
-adjacency between the Ethernet interfaces on IP routers, which can be either
-single-technology or multi-technology. Therefore, the P-PNC reports, within
-the plug-id attribute of this LTP, the LLDP information sent and
-received by the corresponding Ethernet interface on the IP router; such as
-the {BR11,3,BR21,4} plug-id values reported by the Ethernet LTP 3-1 on BR11 and by the Ethernet LTP 4-1 on BR21, as shown in {{fig-inter-domain-link}}.
+- The logical Ethernet LTP (e.g., LTP 3-1 in BR11, as shown in 
+{{fig-inter-domain-link}}), supported by a physical Ethernet LTP (e.g., 
+LTP 3-0 in BR11, as shown in {{fig-inter-domain-link}}), is used to 
+discover the logical adjacency between Ethernet interfaces on IP routers, 
+which can be either single-technology or multi-technology. Therefore, 
+the P-PNC reports, within the plug-id attribute of this LTP, the LLDP 
+information sent and received by the corresponding Ethernet interface 
+on the IP router, such as the {BR11,3,BR21,4} plug-id values reported 
+by the Ethernet LTP 3-1 on BR11 and the Ethernet LTP 4-1 on BR21, as 
+shown in {{fig-inter-domain-link}}.
 
-It is worth noting that in case of an inter-domain Ethernet links, the MDSC cannot discover, using the LLDP
-information reported in the plug-id attributes, the physical
-adjacency between the two Ethernet interfaces on physically adjacent IP routers, because these
-two plug-id values do not match, such as the plug-id values {BR11,3}
-and {BR21,4} shown in {{fig-inter-domain-link}}. However, the MDSC may infer the
-physical intra-domain Ethernet links if it knows a priori, using
-mechanisms which are outside the scope of this document, that the
-Ethernet interfaces on the IP routers either terminates a cross-technology
-link or a single-technology (intra-domain or inter-domain) Ethernet link,
-e.g., as shown in {{fig-inter-domain-link}}.
+It is worth noting that in the case of inter-domain Ethernet links, 
+the MDSC cannot discover, using the LLDP information reported in the 
+plug-id attributes, the physical adjacency between two Ethernet 
+interfaces on physically adjacent IP routers, because these plug-id 
+values do not match, such as the {BR11,3} and {BR21,4} plug-id values 
+shown in {{fig-inter-domain-link}}. However, the MDSC may infer the 
+physical intra-domain Ethernet links if it knows a priori, using 
+mechanisms outside the scope of this document, that the Ethernet 
+interfaces on the IP routers either terminate a cross-technology or 
+single-technology (intra-domain or inter-domain) Ethernet link, e.g., 
+as shown in {{fig-inter-domain-link}}.
 
-The P-PNC can omit reporting the physical Ethernet LTPs when it
-knows, by mechanisms which are outside the scope of this document,
-that the corresponding Ethernet interfaces terminate inter-domain Ethernet links.
+The P-PNC can omit reporting the physical Ethernet LTPs when it 
+knows, through mechanisms outside the scope of this document, that 
+the corresponding Ethernet interfaces terminate inter-domain Ethernet 
+links.
 
-The MDSC can then discover an inter-domain IP link between the two IP
-LTPs that are supported by the two Ethernet LTPs terminating an
-inter-domain Ethernet link, discovered as described in {{ip-inter-domain-link-discovery}},
-e.g., between the IP LTP 3-2 on BR21 and the IP LTP 4-2 on BR22,
-supported respectively by the Ethernet LTP 3-1 on BR11 and by the
-Ethernet LTP 4-1 on BR21, as shown in {{fig-inter-domain-link}}.
+The MDSC can then discover an inter-domain IP link between the two IP 
+LTPs supported by the two Ethernet LTPs terminating an inter-domain 
+Ethernet link, discovered as described in
+{{ip-inter-domain-link-discovery}}, 
+e.g., between IP LTP 3-2 on BR21 and IP LTP 4-2 on BR22, supported 
+respectively by Ethernet LTP 3-1 on BR11 and Ethernet LTP 4-1 on BR21, 
+as shown in {{fig-inter-domain-link}}.
 
 {: #multi-technology-link-discovery}
 
 ## Multi-technology IP Link Discovery
 
-A multi-technology intra-domain IP link and its supporting multi-technology
+A multi-technology intra-domain IP link and its supporting
+multi-technology
 intra-domain Ethernet link are discovered by the P-PNC like any other
-intra-domain IP and Ethernet links, as described in {{packet-topology-discovery}}, and
+intra-domain IP and Ethernet links, as described in
+{{packet-topology-discovery}}, and
 reported at the MPI within the packet and the Ethernet network
 topologies, e.g., as shown in {{fig-multi-technology-link}}.
 
 {::include ./figures/multi-technology-intra-domain-link.md}
-{: #fig-multi-technology-link title="Multi-technology intra-domain Ethernet and IP link discovery"}
+{: #fig-multi-technology-link title="Multi-technology intra-domain
+Ethernet and IP link discovery"}
 
-The Ethernet interface 5 on the P13 router is terminating two Ethernet abstract links:
-- The multi-technology intra-domain Ethernet link between logical Ethernet LTP 5-1 on PE13 and the logical Ethernet LTP 6-1 on BR11;
-- The cross-technology Ethernet link, which is supporting that multi-technology intra-domain Ethernet link, between the physical Ethernet LTPs 5-0 on PE13 and the physical Ethernet LTP 7-0 on the optical NE11.
+The Ethernet interface 5 on the P13 router is terminating two Ethernet
+abstract links:
+- The multi-technology intra-domain Ethernet link between logical
+Ethernet LTP 5-1 on PE13 and the logical Ethernet LTP 6-1 on BR11;
+- The cross-technology Ethernet link, which is supporting that
+multi-technology intra-domain Ethernet link, between the physical
+Ethernet LTPs 5-0 on PE13 and the physical Ethernet LTP 7-0 on the
+optical NE11.
 
 The P-PNC does not report any plug-id information on the logical
 Ethernet LTPs terminating intra-domain Ethernet links, such as the
-LTP 5-1 on PE13 and LTP 6-1 in BR11 shown in {{fig-multi-technology-link}}, since these
+LTP 5-1 on PE13 and LTP 6-1 in BR11 shown in
+{{fig-multi-technology-link}}, since these
 links are discovered by the PNC.
 
 In addition, the P-PNC also reports the physical Ethernet LTPs that
-terminate the cross-technology Ethernet links supporting the multi-technology intra-domain Ethernet links, e.g., the Ethernet LTP 5-0 on PE13 and the
+terminate the cross-technology Ethernet links supporting the
+multi-technology intra-domain Ethernet links, e.g., the Ethernet LTP 5-0
+on PE13 and the
 Ethernet LTP 6-0 on BR11, shown in {{fig-multi-technology-link}}.
 
-The MDSC discovers, using the mechanisms described in {{inter-domain-link-discovery}},
-which cross-technology Ethernet links support the multi-technology intra-domain
+The MDSC discovers, using the mechanisms described in
+{{inter-domain-link-discovery}},
+which cross-technology Ethernet links support the multi-technology
+intra-domain
 Ethernet links, e.g., the link between LTP 5-0 on PE13 and LTP 7-0 on
 NE11, shown in {{fig-multi-technology-link}}.
 
 The MDSC also discovers, from the information provided by the O-PNC
-and described in {{optical-path-discovery}}, which optical tunnels support the
+and described in {{optical-path-discovery}}, which optical tunnels
+support the
 multi-technology intra-domain IP links and therefore the path within the
 optical network that supports a multi-technology intra-domain IP link,
 e.g., as shown in {{fig-multi-technology-link}}.
@@ -1456,38 +1568,38 @@ Ethernet interface on the IP router, e.g., the Ethernet LTP 1-0 and 1-1
 on PE13, shown in {{fig-intra-domain-link}}.
 
 {::include ./figures/single-technology-intra-domain-link.md}
-{: #fig-intra-domain-link title="Single-technology intra-domain Ethernet and IP link discovery"}
+{: #fig-intra-domain-link title="Single-technology intra-domain Ethernet
+and IP link discovery"}
 
-It is worth noting that in case of an intra-domain single-technology
-Ethernet links, the MDSC cannot discover, using the LLDP information
-reported in the plug-id attributes, the physical adjacency
-between the two Ethernet interfaces on physically adjacent IP routers,
-because the two plug-id values do
-not match, such as the plug-id values {PE13,1} and {P16,2} shown in
-{{fig-intra-domain-link}}. However, the MDSC may infer the physical intra-domain
-Ethernet links, e.g., between LTP 1-0 on PE13 and LTP 2-0 on P16, as
-shown in {{fig-intra-domain-link}}, if it knows a priori, using mechanisms which are
-outside the scope of this document, that all the Ethernet interfaces
-on the IP routers either terminates a cross-technology or a single-technology
-(intra-domain or inter-domain) Ethernet link, e.g., as shown in
-{{fig-intra-domain-link}}.
+It is worth noting that in the case of intra-domain single-technology 
+Ethernet links, the MDSC cannot discover, using the LLDP information 
+reported in the plug-id attributes, the physical adjacency between 
+two Ethernet interfaces on physically adjacent IP routers, because 
+the plug-id values do not match, such as {PE13,1} and {P16,2}, as shown 
+in {{fig-intra-domain-link}}. However, the MDSC may infer the physical 
+intra-domain Ethernet links, e.g., between LTP 1-0 on PE13 and LTP 2-0 
+on P16, as shown in {{fig-intra-domain-link}}, if it knows a priori, 
+using mechanisms outside the scope of this document, that all Ethernet 
+interfaces on the IP routers terminate either a cross-technology or 
+single-technology (intra-domain or inter-domain) Ethernet link, e.g., 
+as shown in {{fig-intra-domain-link}}.
 
-The P-PNC can omit reporting the physical Ethernet LTP if it knows,
-by mechanisms which are outside the scope of this document, that the
+The P-PNC can omit reporting the physical Ethernet LTP if it knows, 
+through mechanisms outside the scope of this document, that the 
 intra-domain Ethernet link is single-technology.
 
 {: #lag-discovery}
 
 ## LAG Discovery
 
-The P-PNCs can discover the configuration of the LAG groups within
-its domain and report each intra-domain LAG as an Ethernet bundle
-link, within the Ethernet topology exposed at the MPI.
+The P-PNCs can discover the configuration of LAG groups within its 
+domain and report each intra-domain LAG as an Ethernet bundle link 
+within the Ethernet topology exposed at the MPI.
 
-This is done bundling multiple single-domain Ethernet links, as shown
-in {{fig-lag}}. For example, the Ethernet bundled link between the
-Ethernet LTP 5-1 on BR21 and the Ethernet LTP 6-1 on P24, is built
-from the Ethernet links setup respectively:
+This is done by bundling multiple single-domain Ethernet links, as 
+shown in {{fig-lag}}. For example, the Ethernet bundled link between 
+Ethernet LTP 5-1 on BR21 and Ethernet LTP 6-1 on P24 is built from 
+the Ethernet links set up respectively:
 
 - between the Ethernet LTP 1-1 on BR21 and the Ethernet LTP 2-1 on
 P24; and
@@ -1498,38 +1610,45 @@ P24.
 {::include ./figures/lag.md}
 {: #fig-lag title="LAG"}
 
-The mechanisms used by the MDSC to discover single-technology and multi-technology intra-domain LAG link is the same (the only difference being
-whether the bundled links are single-technology or multi-technology).
+The mechanisms used by the MDSC to discover single-technology and 
+multi-technology intra-domain LAG links are the same, with the only 
+difference being whether the bundled links are single-technology or 
+multi-technology.
 
-Instead, the mechanisms used by the MDSC to discover single-technology
-inter-domain LAG links between two BRs are different and outside the
-scope of this document since they do not imply any cross-technology
-coordination between packet and optical domains.
+However, the mechanisms used by the MDSC to discover single-technology 
+inter-domain LAG links between two BRs are different and outside the 
+scope of this document, as they do not imply cross-technology
+coordination 
+between packet and optical domains.
 
-As described in {{packet-topology-discovery}}, the mechanisms used by the P-PNC to
-discover the configuration of the LAG groups within its domain, such
+As described in {{packet-topology-discovery}}, the mechanisms used by the 
+P-PNC to discover the configuration of LAG groups within its domain, such 
 as LLDP {{IEEE_802.1AB}}, are outside the scope of this document.
 
-However, it is worth noting that according to {{IEEE_802.1AB}}, LLDP
-can be configured on a LAG group (Aggregated Port) and/or on any
-number of its LAG members (Aggregation Ports).
+It is worth noting that according to {{IEEE_802.1AB}}, LLDP can be 
+configured on a LAG group (Aggregated Port) and/or on any number of its 
+LAG members (Aggregation Ports).
 
 If LLDP is enabled on both LAG members and groups, two types of LLDP
 packets are transmitted by the routers and received by the optical
-nodes on some cross-technology Ethernet links: one sent for the LLDP session
+nodes on some cross-technology Ethernet links: one sent for the LLDP
+session
 configured at LAG member (Aggregation Port)level and another one for
 the LLDP session configured at LAG group (Aggregated Port)level. This
 could cause some issues when LLDP snooping is used to discover the
-cross-technology Ethernet links, as defined in {{cross-technology-link-discovery}}.
+cross-technology Ethernet links, as defined in
+{{cross-technology-link-discovery}}.
 
-The cross-technology Ethernet link discovery is based only on the LLDP session
+The cross-technology Ethernet link discovery is based only on the LLDP
+session
 configured on the LAG members (Aggregation Ports) to allow discovery
 of these links independently from the configuration of the underlay
 optical tunnel or from the LAG group.
 
 To avoid any ambiguity on how the optical nodes can identify which LLDP
 packets belong to which LLDP session, the P-PNC can disable the LLDP
-sessions on the LAG groups configured by the MDSC (e.g., the multi-technology single-domain LAG groups configured using the mechanisms
+sessions on the LAG groups configured by the MDSC (e.g., the
+multi-technology single-domain LAG groups configured using the mechanisms
 described in {{lag-setup}}), keeping the LLDP sessions on the LAG
 members enabled.
 
@@ -1538,7 +1657,8 @@ field in the Link Aggregation TLV defined in Annex F of {{IEEE_802.1AX}})
 that allow the optical node to identify which LLDP packets
 belong to which LLDP session: the O-PNC can then use only the LLDP
 information from the LLDP sessions configured on the LAG members to
-support the cross-technology Ethernet link discovery mechanisms defined in {{cross-technology-link-discovery}}.
+support the cross-technology Ethernet link discovery mechanisms defined
+in {{cross-technology-link-discovery}}.
 
 {: #vpn-discovery}
 
@@ -1552,7 +1672,8 @@ service, using the L2NM and L3NM TE service mapping models.
 The MDSC can use the information mentioned above together with the
 packet TE path, packet topology, multi-technology IP links, optical
 topology and optical path information discovered as described in the
-previous sections, to discover the multi-technology path used to carry the
+previous sections, to discover the multi-technology path used to carry
+the
 traffic for each L2/L3 VPN service.
 
 {: #inventory-discovery}
@@ -1589,11 +1710,13 @@ requirements (e.g., bandwidth, TE metric bounds, SRLG disjointness,
 nodes/links/domains inclusion/exclusion) and find the TE paths that
 meet these TE requirements (see {{vpn-overview}}).
 
-For example, considering the L3VPN in {{fig-vpn-topo}} and {{fig-vpn-path}}, the MDSC
+For example, considering the L3VPN in {{fig-vpn-topo}} and
+{{fig-vpn-path}}, the MDSC
 finds that:
 
 - PE13-P16-PE14 TE path already exists but have not enough bandwidth
-to support the new L3VPN, as described in {{te-path-discovery}};, and that:
+to support the new L3VPN, as described in {{te-path-discovery}};, and
+that:
 
    - the IP link(s) between PE13 and P16 has not enough bandwidth
    to support increasing the bandwidth of that TE path, as
@@ -1602,7 +1725,8 @@ to support the new L3VPN, as described in {{te-path-discovery}};, and that:
    - a new underlay optical tunnel could be setup to increase the
    bandwidth of the IP link(s) between PE13 and P16 to support
    increasing the bandwidth of that overlay TE path, as described
-   in {{optical-path-computation}}. The dimensioning of the underlay optical
+   in {{optical-path-computation}}. The dimensioning of the underlay
+optical
    tunnel is decided by the MDSC based on the TE requirements
    (e.g., the bandwidth) requested by the TE path and on its
    multi-layer optimization policy, which is an internal MDSC
@@ -1614,11 +1738,11 @@ to support the new L3VPN, as described in {{te-path-discovery}};, and that:
    the L2/L3 VPN service or because there is no TE path between
    PE13 and PE23.
 
-As described in {{path-computation-overview}}, with partial summarization, the MDSC
-will use the TE topology information provided by the P-PNCs and the
-results of the path computation requests sent to the O-PNCs, as
-described in {{optical-path-computation}}, to compute the multi-layer/multi-domain
-path between PE13 and PE23.
+As described in {{path-computation-overview}}, with partial 
+summarization, the MDSC will use the TE topology information provided 
+by the P-PNCs and the results of the path computation requests sent to 
+the O-PNCs, as described in {{optical-path-computation}}, to compute 
+the multi-layer/multi-domain path between PE13 and PE23.
 
 For example, the multi-layer/multi-domain performed by the MDSC could
 require the setup of:
@@ -1630,77 +1754,76 @@ new IP link, as described in {{multi-technology-link-setup}};
 bandwidth of the IP link(s) between BR21 and P24, as described in
 {{multi-technology-link-setup}}.
 
-When the setup of the L2/L3 VPN network service requires multi-domain
-and multi-layer coordination, the MDSC is also responsible for
-coordinating the network configuration required to realize the
-request network service across the appropriate optical and packet
-domains.
+When setting up the L2/L3 VPN network service requires multi-domain 
+and multi-layer coordination, the MDSC is also responsible for 
+coordinating the network configuration needed to realize the requested 
+network service across the appropriate optical and packet domains.
 
 The MDSC would therefore request:
 
 - the O-PNC1 to setup a new optical tunnel between the ROADMs
-connected to PE13 and P16, as described in {{multi-technology-link-setup}};
+connected to PE13 and P16, as described in
+{{multi-technology-link-setup}};
 
 - the P-PNC1 to update the configuration of the existing IP link, in
-case of LAG, or configure a new IP link, in case of Equal Cost Multi-Path (ECMP), between
+case of LAG, or configure a new IP link, in case of Equal Cost Multi-Path
+(ECMP), between
 PE13 and P16, as described in {{multi-technology-link-setup}};
 
 - the P-PNC1 to update the bandwidth of the selected TE path between
 PE13 and PE14, as described in {{te-path-config}}.
 
-After that, the MDSC requests P-PNC2 to setup a TE path between BR21
-and PE23, with an explicit path (BR21, P24, PE23) to constrain this
-new TE path to use the new underlay optical tunnel setup between BR21
-and P24, as described in {{te-path-config}}. The P-PNC2 properly configures
-the routers within its domain to setup the requested path and returns
-to the MDSC the information which is needed for multi-domain TE path
-stitching. For example, in case of inter-domain SR-TE, the P-PNC2,
-knowing the node and the adjacency SIDs assigned within its domain,
-can install the proper SR policy, or hierarchical policies, within
-BR21 and returns to the MDSC the binding SID it has assigned to this
-policy in BR21.
+After that, the MDSC requests P-PNC2 to set up a TE path between BR21 
+and PE23, with an explicit path (BR21, P24, PE23) to constrain the 
+new TE path to use the underlay optical tunnel setup between BR21 and 
+P24, as described in {{te-path-config}}. The P-PNC2 properly configures 
+the routers within its domain to set up the requested path and returns 
+the information needed for multi-domain TE path stitching. For example, 
+in inter-domain SR-TE, the P-PNC2, knowing the node and adjacency SIDs 
+assigned within its domain, can install the proper SR policy or 
+hierarchical policies within BR21 and return to the MDSC the binding 
+SID assigned to this policy in BR21.
 
-Then the MDSC requests P-PNC1 to setup a TE path between PE13 and
-BR11, with an explicit path (PE13, BR11) to constrain this new TE
-path to use the new underlay optical tunnel setup between PE13 and
-BR11, specifying also which inter-domain link should be used to send
-traffic to BR21 and the information to be used for the multi-domain
-TE path stitching, as described in {{te-path-discovery}} (e.g., in case of
-inter-domain SR-TE, the binding SID  that has been assigned by P-PNC2
-to the corresponding SR policy in BR21). The P-PNC1 properly
-configures the routers within its domain to setup the requested path
-and the multi-domain TE path stitching. For example, in case of
-inter-domain SR-TE, the P-PNC1, knowing also the node and the
-adjacency SIDs assigned within its domain and the EPE SID assigned by
-P-PNC1 to the inter-domain link between BR11 and BR21, and the
-binding SID assigned by P-PNC2, installs the proper policy, or
-policies, within PE13.
+Then the MDSC requests P-PNC1 to set up a TE path between PE13 and 
+BR11, with an explicit path (PE13, BR11) to constrain the new TE path 
+to use the underlay optical tunnel setup between PE13 and BR11, 
+specifying which inter-domain link should be used to send traffic to 
+BR21 and the information for multi-domain TE path stitching, as 
+described in {{te-path-discovery}} (e.g., in inter-domain SR-TE, the 
+binding SID assigned by P-PNC2 to the corresponding SR policy in BR21). 
+The P-PNC1 properly configures the routers within its domain to set up 
+the requested path and the multi-domain TE path stitching. For example, 
+in inter-domain SR-TE, the P-PNC1, knowing the node and adjacency SIDs 
+assigned within its domain and the PE SID assigned by P-PNC1 to the 
+inter-domain link between BR11 and BR21, along with the binding SID 
+assigned by P-PNC2, installs the proper policy or policies within PE13.
 
-Once the TE paths have been selected and, if needed, setup/modified,
-the MDSC can request to both P-PNCs to configure the L3VPN and its
-binding with the selected TE paths, as described in {{vpn-setup}}.
+Once the TE paths have been selected and, if needed, set up or modified, 
+the MDSC can request both P-PNCs to configure the L3VPN and its binding 
+with the selected TE paths, as described in {{vpn-setup}}.
 
 {: #optical-path-computation}
 
 ## Optical Path Computation
 
-As described in {{path-computation-overview}}, the optical path computation is
-usually performed by the O-PNCs.
+As described in {{path-computation-overview}}, optical path 
+computation is usually performed by the O-PNCs.
 
-When performing multi-layer/multi-domain path computation, the MDSC
-can delegate the O-PNC for single-domain optical path computation.
+When performing multi-layer/multi-domain path computation, the MDSC 
+can delegate single-domain optical path computation to the O-PNC.
 
-As described in {{optical-topology-discovery}}, {{inter-domain-link-discovery}} and {{multi-technology-link-discovery}}, there is a one-to-one
-relationship between a multi-layer intra-domain IP link and its
-underlay optical tunnel. Therefore, the properties of an optical path
-between two optical TTPs, as computed by the O-PNC, can be used by
-the MDSC to infer the properties of the associated multi-layer
-single-domain IP link.
+As described in {{optical-topology-discovery}}, {{inter-domain-link-discovery}}, 
+and {{multi-technology-link-discovery}}, there is a one-to-one 
+relationship between a multi-layer intra-domain IP link and its underlay 
+optical tunnel. Therefore, the properties of an optical path between 
+two optical TTPs, as computed by the O-PNC, can be used by the MDSC to 
+infer the properties of the associated multi-layer single-domain IP link.
 
-As discussed in {{!I-D.ietf-teas-yang-path-computation}}, there are two options to request an
-O-PNC to perform optical path computation: either via a "compute-only" TE tunnel path, using the generic TE tunnel YANG data model
-defined in {{!I-D.ietf-teas-yang-te}} or via the path computation RPC defined in
-{{!I-D.ietf-teas-yang-path-computation}}.
+As discussed in {{!I-D.ietf-teas-yang-path-computation}}, there are two 
+options to request an O-PNC to perform optical path computation: either 
+via a "compute-only" TE tunnel path, using the generic TE tunnel YANG 
+data model defined in {{!I-D.ietf-teas-yang-te}}, or via the path 
+computation RPC defined in {{!I-D.ietf-teas-yang-path-computation}}.
 
 This draft assumes that the path computation RPC is used.
 
@@ -1715,61 +1838,62 @@ scope.
 
 ## Multi-technology IP Link Setup
 
-As described in {{optical-path-computation}}, there is a one-to-one relationship
-between a multi-technology intra-domain IP link and its underlay optical
-tunnel.
+As described in {{optical-path-computation}}, there is a one-to-one 
+relationship between a multi-technology intra-domain IP link and its 
+underlay optical tunnel.
 
-Therefore, to setup a new multi-technology intra-domain IP link, the MDSC
-requires the O-PNC to setup the  optical tunnel (using either the WDM
-Tunnel model or the OTN Tunnel model, if the optional OTN switching
-is supported) within the optical network and to steer the client
-traffic between the two cross-technology Ethernet links over that optical tunnel,
-using either the Ethernet Client Signal Model (for frame-based
-transport) or the Transparent CBR Client Signal Model (for
-transparent transport).
+Therefore, to set up a new multi-technology intra-domain IP link, 
+the MDSC requires the O-PNC to set up the optical tunnel (using either 
+the WDM Tunnel model or the OTN Tunnel model, if optional OTN switching 
+is supported) within the optical network and steer client traffic 
+between the two cross-technology Ethernet links over that optical tunnel, 
+using either the Ethernet Client Signal Model (for frame-based transport) 
+or the Transparent CBR Client Signal Model (for transparent transport).
 
-For example, with a reference to {{fig-multi-technology-link-2}}, the MDSC can request the
-O-PNC1 to setup an optical tunnel between the optical TTPs (7) on
-NE11 and (8) on NE12 and to steer over this tunnel the client traffic
-between LTP (7-0) on NE11 and LTP (8-0) on NE12.
+For example, with reference to {{fig-multi-technology-link-2}}, the 
+MDSC can request O-PNC1 to set up an optical tunnel between optical 
+TTPs (7) on NE11 and (8) on NE12 and steer client traffic over this 
+tunnel between LTP (7-0) on NE11 and LTP (8-0) on NE12.
 
 {::include ./figures/multi-technology-intra-domain-link.md}
 {: #fig-multi-technology-link-2 title="Multi-technology IP link setup"}
 
-Note: {{fig-multi-technology-link-2}} is an exact copy of {{fig-multi-technology-link}}.
+Note: {{fig-multi-technology-link-2}} is an exact copy of 
+{{fig-multi-technology-link}}.
 
-After the optical tunnel has been setup and the client traffic
-steering configured, the two IP routers can exchange Ethernet frames
+After the optical tunnel has been set up and the client traffic 
+steering configured, the two IP routers can exchange Ethernet frames 
 between themselves, including LLDP messages.
 
-If LLDP {{IEEE_802.1AB}} or any other discovery mechanisms, which are
-outside the scope of this document, is used between the adjacency
-between the two IP routers' ports, the P-PNC can automatically discover
-the underlay multi-technology single-domain Ethernet link being set up by
-the MDSC and report it to the P-PNC, as described in {{multi-technology-link-discovery}}.
+If LLDP {{IEEE_802.1AB}} or any other discovery mechanisms, outside 
+the scope of this document, are used between the adjacency of the two 
+IP routers' ports, the P-PNC can automatically discover the underlay 
+multi-technology single-domain Ethernet link set up by the MDSC and 
+report it to the P-PNC, as described in {{multi-technology-link-discovery}}.
 
-Otherwise, if there are no automatic discovery mechanisms, the MDSC
-can configure this multi-technology single-domain Ethernet link at the MPI
-of the P-PNC.
+Otherwise, if no automatic discovery mechanisms are used, the MDSC 
+can configure this multi-technology single-domain Ethernet link at 
+the MPI of the P-PNC.
 
-The two Ethernet LTPs terminating this multi-technology single-domain
-Ethernet link are supported by the two underlay Ethernet LTPs
-terminating the two cross-technology Ethernet links, e.g., the LTP 5-1 on PE13 and
-6-1 on BR11 shown in {{fig-multi-technology-link-2}}.
+The two Ethernet LTPs terminating this multi-technology single-domain 
+Ethernet link are supported by the two underlay Ethernet LTPs 
+terminating the two cross-technology Ethernet links, e.g., LTP 5-1 on 
+PE13 and 6-1 on BR11, as shown in {{fig-multi-technology-link-2}}.
 
-After the multi-technology single-domain Ethernet link has been configured
-by the MDSC or discovered by the P-PNC, the corresponding multi-technology
-single-domain IP link can also be configured either by the MDSC or by
-the P-PNC.
+After the multi-technology single-domain Ethernet link has been 
+configured by the MDSC or discovered by the P-PNC, the corresponding 
+multi-technology single-domain IP link can also be configured either 
+by the MDSC or the P-PNC.
 
-This document assumes that this IP link is configured by the P-PNC.
+This document assumes that the IP link is configured by the P-PNC.
 
-It is worth noting that if LAG is not supported within the domain
-controlled by the P-PNC, the P-PNC can configure the multi-technology
-single-domain IP link as soon as the underlay multi-technology single-domain Ethernet link is either discovered by the P-PNC or configured
-by the MDSC at the MPI. However, if LAG is supported the P-PNC has
-not enough information to know whether the discovered/configured
-multi-technology single-domain Ethernet link would be:
+It is worth noting that if LAG is not supported within the domain 
+controlled by the P-PNC, the P-PNC can configure the multi-technology 
+single-domain IP link as soon as the underlay multi-technology 
+single-domain Ethernet link is either discovered by the P-PNC or 
+configured by the MDSC at the MPI. However, if LAG is supported, the 
+P-PNC lacks enough information to determine whether the discovered or 
+configured multi-technology single-domain Ethernet link would be:
 
 1. Used to support a multi-technology single-domain IP link;
 
@@ -1777,89 +1901,94 @@ multi-technology single-domain Ethernet link would be:
 
 3. Added to an existing LAG group.
 
-Therefore the P-PNC does not take any further action after a multi-technology single-domain Ethernet link is discovered or configured by the
-MDSC at the MPI.
+The MDSC can request the P-PNC to configure a new multi-technology 
+single-domain IP link, supported by the just discovered or configured 
+multi-technology single-domain Ethernet link, by creating an IP link 
+within the running datastore of the P-PNC MPI. Only the IP link, IP 
+LTPs, and the reference to the supporting multi-technology single-domain 
+Ethernet link are configured by the MDSC. All other configuration is 
+provided by the P-PNC.
 
-The MDSC can request the P-PNC to configure a new multi-technology single-domain IP link, supported by the the just discovered or configured
-multi-technology single-domain Ethernet link, by creating an IP link
-within the running datastore of the P-PNC MPI. Only the IP link, IP
-LTPs and the reference to the supporting multi-technology single-domain
-Ethernet link are configured by the MDSC. All the other configuration
-is provided by the P-PNC.
+For example, with reference to {{fig-multi-technology-link-2}}, the 
+MDSC can request P-PNC1 to set up a multi-technology single-domain 
+IP link between IP LTP 5-2 on PE13 and IP LTP 6-2 on BR11, supported 
+by the multi-technology single-domain Ethernet link between ETH LTP 
+5-1 on PE13 and ETH LTP 6-1 on BR11.
 
-For example, with a reference to {{fig-multi-technology-link-2}}, the MDSC can request the
-P-PNC1 to setup a multi-technology single-domain IP Link between IP LTP 5-2 on PE13 and IP LTP 6-2 on BR11 supported by the multi-technology single-domain Ethernet link between ETH LTP 5-1 on PE13 and ETH LTP 6-1 on
-BR11.
-
-The P-PNC configures the requested multi-technology single-domain IP link
-and, once finished, reports it to the MDSC within the IP topology
-exposed at its MPI.
+The P-PNC configures the requested multi-technology single-domain 
+IP link and, once finished, reports it to the MDSC within the IP 
+topology exposed at its MPI.
 
 {: #lag-setup}
 
 ### Multi-technology LAG Setup
 
-The P-PNC configures a new LAG group between two routers when the
-MDSC creates at the MPI a new Ethernet bundled link (using the
-bundled-link container defined in {{!RFC8795}}) bundling the multi-technology
-single-domain Ethernet link(s) being created, as described above.
+The P-PNC configures a new LAG group between two routers when the 
+MDSC creates a new Ethernet bundled link at the MPI (using the 
+bundled-link container defined in {{!RFC8795}}), bundling the 
+multi-technology single-domain Ethernet link(s) being created, as 
+described above.
 
-When a new LAG link is created, it is also recommended to configure
-the minimum number of active member links required to consider the
-LAG link as being up. For example, a LAG link with three members can
-be considered up when only one member link fails and down when at
-least two member links fail.
+When a new LAG link is created, it is recommended to configure the 
+minimum number of active member links required to consider the LAG 
+link as up. For example, a LAG link with three members can be 
+considered up when only one member link fails and down when at least 
+two member links fail.
 
-The attribute required to configure the minimum number of active
-member links is missing in {{!I-D.ietf-ccamp-eth-client-te-topo-yang}} and this is identified as a
-gap in {{conclusions}}.
+The attribute required to configure the minimum number of active 
+member links is missing in {{!I-D.ietf-ccamp-eth-client-te-topo-yang}} 
+and is identified as a gap in {{conclusions}}.
 
-It is worth noting that a new LAG group can be created to bundle one
+It is worth noting that a new LAG group can be created to bundle one 
 or more multi-technology single-domain Ethernet link(s).
 
-For example, with a reference to {{fig-lag}}, the MDSC can request the
-P-PNC2 to setup an Ethernet bundled link between the Ethernet LTP 5-1
-on BR21 and the Ethernet LTP 6-1 on P24, bundling the multi-technology
-single-domain Ethernet link between the Ethernet LTP 1-1 on BR21 and
-the Ethernet LTP 2-1 on P24.
+For example, with reference to {{fig-lag}}, the MDSC can request 
+P-PNC2 to set up an Ethernet bundled link between Ethernet LTP 5-1 on 
+BR21 and Ethernet LTP 6-1 on P24, bundling the multi-technology 
+single-domain Ethernet link between Ethernet LTP 1-1 on BR21 and 
+Ethernet LTP 2-1 on P24.
 
-It is worth noting that the MDSC needs to create also the Ethernet
+It is also worth noting that the MDSC needs to create the Ethernet 
 LTPs terminating the Ethernet bundled link.
 
-The MDSC can request the P-PNC to configure a new multi-technology single-domain IP link, supported by the the just configured Ethernet bundled
-link, following the same procedure described in {{multi-technology-link-setup}} above.
+The MDSC can request the P-PNC to configure a new multi-technology 
+single-domain IP link, supported by the just configured Ethernet 
+bundled link, following the same procedure described in 
+{{multi-technology-link-setup}} above.
 
 For example, with a reference to {{fig-lag}}, the MDSC can request the
-P-PNC2 to setup a multi-technology single-domain IP Link between IP LTP 5-2 on BR21 and IP LTP 6-2 on P24 supported by the Ethernet bundle link
+P-PNC2 to setup a multi-technology single-domain IP Link between IP LTP
+5-2 on BR21 and IP LTP 6-2 on P24 supported by the Ethernet bundle link
 between ETH LTP 5-1 on BR21 and the Ethernet LTP 6-1 on P24.
 
 ### Multi-technology LAG Update
 
-The P-PNC adds new member(s) to an existing LAG group when the MDSC
-updates at the MPI the configuration of an existing Ethernet bundled
-link adding the multi-technology single-domain Ethernet link(s) being
+The P-PNC adds new member(s) to an existing LAG group when the MDSC 
+updates the configuration of an existing Ethernet bundled link at the 
+MPI, adding the multi-technology single-domain Ethernet link(s) being 
 created, as described above.
 
-When member links are added or removed from a LAG link, the minimum
-number of active member links required to consider the LAG link as
-being up may also need to be updated.
+When member links are added or removed from a LAG link, the minimum 
+number of active member links required to consider the LAG link as up 
+may also need to be updated.
 
-For example, with a reference to {{fig-lag}}, the MDSC can request the
-P-PNC2 to add the multi-technology single-domain Ethernet link setup
-between the Ethernet LTP 3-1 on BR21 and the Ethernet LTP 4-1 on P24
-to the existing Ethernet bundle link setup between the Ethernet LTP
-5-1 on node BR21 and the Ethernet LTP 6-1 on node P24.
+For example, with reference to {{fig-lag}}, the MDSC can request 
+P-PNC2 to add the multi-technology single-domain Ethernet link set up 
+between Ethernet LTP 3-1 on BR21 and Ethernet LTP 4-1 on P24 to the 
+existing Ethernet bundle link set up between Ethernet LTP 5-1 on node 
+BR21 and Ethernet LTP 6-1 on node P24.
 
-After the LAG configuration has been updated, the P-PNC can also
-update the bandwidth information of the multi-technology single-domain IP
-link supported by the updated Ethernet bundled link.
+After the LAG configuration has been updated, the P-PNC can also update 
+the bandwidth information of the multi-technology single-domain IP link 
+supported by the updated Ethernet bundled link.
 
 {: #multi-technology-path-properties}
 
 ### Multi-technology TE path properties Configuration
 
 The MDSC can discover the TE path properties (e.g., the list of
-SRLGs, the delay) of a multi-technology IP link from the TE properties of:
+SRLGs, the delay) of a multi-technology IP link from the TE properties
+of:
 
 - the IP LTPs terminating the multi-technology IP link (e.g., the list of
 SRLGs reported by the P-PNC using the packet TE topology model);
@@ -1867,7 +1996,8 @@ SRLGs reported by the P-PNC using the packet TE topology model);
 - the optical path (e.g., the list of SRLGs reported by the O-PNC
 using the WDM or OTN tunnel model); and
 
-- the cross-domain links (e.g., the list of SRLGs reported by the O-PNC and P-PNC respectively, using the WSON and/or flexi-grid, the
+- the cross-domain links (e.g., the list of SRLGs reported by the O-PNC
+and P-PNC respectively, using the WSON and/or flexi-grid, the
 OTN and the packet TE topology models).
 
 The MDSC can also report this information to the P-PNC by properly
@@ -1875,7 +2005,8 @@ configuring the multi-technology IP link properties using the packet TE
 topology model at the packet PNC MPI.
 
 This information is used by the P-PNC at least when computing the
-local protection path, as described in {{te-path-config}}, e.g., to ensure
+local protection path, as described in {{te-path-config}}, e.g., to
+ensure
 that the local protection path is SRLG disjoint with the primary
 path.
 
@@ -1895,36 +2026,47 @@ the MPI could be done using the generic TE tunnel YANG data model,
 defined in {{!I-D.ietf-teas-yang-te}}, with packet technology-specific
 augmentations, described in {{packet-yang}}.
 
-When a new TE path needs to be setup, the MDSC can use the {{!I-D.ietf-teas-yang-te}}
-model to request the P-PNC to set it up, properly specifying
-the path constraints, such as the explicit path, to force the P-PNC
-to setup an TE path that meets the end-to-end TE and binding
-constraints and uses the optical tunnels setup by the MDSC for the
-purpose of supporting this new TE path.
+When a new TE path needs to be setup, the MDSC can use the 
+{{!I-D.ietf-teas-yang-te}} model to request the P-PNC to set it up, 
+properly specifying the path constraints, such as the explicit path, 
+to ensure the P-PNC sets up a TE path that meets the end-to-end TE 
+and binding constraints and uses the optical tunnels set up by the 
+MDSC to support this new TE path.
 
-The {{!I-D.ietf-teas-yang-te}} model supports requesting the setup of both end-to-end as well as segment TE tunnels (within one domain).
+The {{!I-D.ietf-teas-yang-te}} model supports requesting the setup of
+both end-to-end as well as segment TE tunnels (within one domain).
 
 In the latter case, the technology-specific augmentations should
 allow the configuration of the information needed for multi-domain TE
 path stitching.
 
-For example, the SR-TE specific augmentations of the {{!I-D.ietf-teas-yang-te}}
+For example, the SR-TE specific augmentations of the
+{{!I-D.ietf-teas-yang-te}}
 model should be defined to allow the MDSC to configure the binding
 SIDs to be used for the multi-domain SR-TE path stitching and to
 allow the P-PNC to report the binding SID assigned to the segment TE
 paths. Note that the assigned binding SID should be persistent in
 case IP router or P-PNC rebooting.
 
-The MDSC can also use the {{!I-D.ietf-teas-yang-te}} model to request the P-PNC to
+The MDSC can also use the {{!I-D.ietf-teas-yang-te}} model to request the
+P-PNC to
 increase the bandwidth allocated to an existing TE path, and, if
-needed, also on its reverse TE path. The {{!I-D.ietf-teas-yang-te}} model supports
+needed, also on its reverse TE path. The {{!I-D.ietf-teas-yang-te}} model
+supports
 both symmetric and asymmetric bandwidth configuration in the two
 directions.
 
 \[Editor's Note:] Add some text about the protection options (to
-further discuss whether to put this text here or in {{multi-technology-link-setup}}).
+further discuss whether to put this text here or in
+{{multi-technology-link-setup}}).
 
-The MDSC also request the P-PNC to configure local protection mechanisms. For example, the FRR local protection, as defined in {{?RFC4090}} in case of MPLS-TE domain or the TI-LFA local protection, as defined in {{?I-D.ietf-rtgwg-segment-routing-ti-lfa}} in case of SR-TE domain. The  mechanisms to request the configuration TI-LFA local protection for SR-TE paths using the {{!I-D.ietf-teas-yang-te}} are a gap in the current YANG models.
+The MDSC also request the P-PNC to configure local protection mechanisms.
+For example, the FRR local protection, as defined in {{?RFC4090}} in case
+of MPLS-TE domain or the TI-LFA local protection, as defined in
+{{?I-D.ietf-rtgwg-segment-routing-ti-lfa}} in case of SR-TE domain. The 
+mechanisms to request the configuration TI-LFA local protection for SR-TE
+paths using the {{!I-D.ietf-teas-yang-te}} are a gap in the current YANG
+models.
 
 The requested local protection mechanisms within the P-PNC domain are
 configured by the P-PNC through implementation specific mechanisms
@@ -1932,8 +2074,11 @@ which are outside the scope of this document.
 
 The P-PNC takes into account the multi-layer TE path properties
 (e.g., SRLG information), configured by the MDSC as described in
-{{multi-technology-path-properties}}, when computing the protection configuration (e.g., in
-case of SR-TE domains, the TI-LFA post-convergence path or, in case of MPLS-TE domain, the FRR backup tunnel) for multi-technology single-domain IP links.
+{{multi-technology-path-properties}}, when computing the protection
+configuration (e.g., in
+case of SR-TE domains, the TI-LFA post-convergence path or, in case of
+MPLS-TE domain, the FRR backup tunnel) for multi-technology single-domain
+IP links.
 
 SR-TE path setup and update (e.g., bandwidth increase) through MPI is
 identified as a gap requiring further work, which is outside of the
@@ -1943,63 +2088,70 @@ scope of this draft.
 
 ## L2/L3 VPN Network Service Setup
 
-The MDSC can use the L2NM and L3NM network service models to request
-the P-PNCs to setup L2/L3 VPN services and the L2NM and L3NM TE
-service mapping models to request the P-PNCs to configure the PE
-routers to steer the L2/L3 VPN traffic to the selected TE tunnels
+The MDSC can use the L2NM and L3NM network service models to request 
+the P-PNCs to setup L2/L3 VPN services, and the L2NM and L3NM TE 
+service mapping models to request the P-PNCs to configure the PE 
+routers to steer the L2/L3 VPN traffic to the selected TE tunnels 
 (e.g., MPLS-TE or SR-TE).
 
-It is worth noting that the L2NM and L3NM TE service mapping models,
-defined in {{?I-D.ietf-teas-te-service-mapping-yang}}, provide a list of TE tunnel(s) that should be used
-to forward L2/L3 VPN traffic between the two PEs terminating the
-listed TE tunnel(s). If the list contains more than one TE tunnel for
-the same pair of PEs, these TE tunnels are used for load balancing
-the associated L2/L3 VPN traffic between the same set of two PEs.
+It is worth noting that the L2NM and L3NM TE service mapping models, 
+defined in {{?I-D.ietf-teas-te-service-mapping-yang}}, provide a list 
+of TE tunnel(s) that should be used to forward L2/L3 VPN traffic 
+between the two PEs terminating the listed TE tunnel(s). If the list 
+contains more than one TE tunnel for the same pair of PEs, these TE 
+tunnels are used to load balance the associated L2/L3 VPN traffic 
+between the same set of two PEs.
 
-The possibility to request splitting the traffic, between multiple TE
-tunnels for the same PEs pair, in a different way than load balancing
-is identified as a gap requiring further work and outside of the
-scope of this draft.
+The possibility to request splitting the traffic between multiple TE 
+tunnels for the same PE pair in a way other than load balancing is 
+identified as a gap requiring further work and is outside the scope 
+of this draft.
 
 {: #conclusions}
 
 # Conclusions
 
-The analysis provided in this document has shown that the IETF YANG
-models described in 3.2 provides useful support for Packet Optical
-Integration (POI) scenarios for resource discovery (network topology,
-service, tunnels and network inventory discovery) as well as for
-supporting multi-layer/multi-domain L2/L3 VPN network services.
+The analysis provided in this document shows that the IETF YANG models 
+described in 3.2 provide useful support for Packet Optical Integration 
+(POI) scenarios for resource discovery (network topology, service, 
+tunnels, and network inventory discovery), as well as for supporting 
+multi-layer/multi-domain L2/L3 VPN network services.
 
-Few gaps have been identified to be addressed by the relevant IETF
-Working Groups:
+The following gaps were identified that may need to be addressed by 
+the relevant IETF Working Groups:
 
 - how both WSON and Flexi-grid topology models could be used
 together (through multi-inheritance): this gap has been identified
 in {{optical-topology-discovery}};.
 
 - network inventory model: this gap has been identified in
-{{inventory-discovery}} and the solution in {{?I-D.ietf-ivy-network-inventory-yang}} has been proposed to
+{{inventory-discovery}} and the solution in
+{{?I-D.ietf-ivy-network-inventory-yang}} has been proposed to
 resolve it;
 
 - technology-specific augmentations of the path computation RPC,
-defined in {{!I-D.ietf-teas-yang-path-computation}} for optical networks: this gap has been
-identified in {{optical-path-computation}} and the solution in {{?I-D.ietf-ccamp-optical-path-computation-yang}}
+defined in {{!I-D.ietf-teas-yang-path-computation}} for optical networks:
+this gap has been
+identified in {{optical-path-computation}} and the solution in
+{{?I-D.ietf-ccamp-optical-path-computation-yang}}
 has been proposed to resolve it;
 
 - relationship between a common discovery mechanisms applicable to
-access links, inter-domain IP links and cross-technology Ethernet links and the
+access links, inter-domain IP links and cross-technology Ethernet links
+and the
 UNI topology discover mechanism defined in {{?RFC9408}}: this gap has
 been identified in {{packet-topology-discovery}};
 
 - a mechanism applicable to the P-PNC NBI to configure the SR-TE
 paths. Technology-specific augmentations of TE Tunnel model,
-defined in {{!I-D.ietf-teas-yang-te}}, are foreseen in section 1 of {{!I-D.ietf-teas-yang-te}}
+defined in {{!I-D.ietf-teas-yang-te}}, are foreseen in section 1 of
+{{!I-D.ietf-teas-yang-te}}
 but not yet defined: this gap has been identified in {{te-path-config}};
 
 - an attribute, which is used to configure the minimum number of
 active member links required to consider the LAG link as being up,
-is missing from the topology model defined in {{!I-D.ietf-ccamp-eth-client-te-topo-yang}}: this
+is missing from the topology model defined in
+{{!I-D.ietf-ccamp-eth-client-te-topo-yang}}: this
 gap has been identified in {{lag-setup}};
 
 - a mechanism to configure splitting the L2/L3 VPN traffic, between
@@ -2009,19 +2161,20 @@ load balancing: this gap has been identified in {{vpn-setup}};
 - a mechanism to report client connectivity constraints imposed by
 some muxponder design: this gap has been identified in {{muxponder}}.
 
-Although not applicable to this document, it has been noted that
-being able to use WSON and Flexi-grid topology models together
-(through multi-inheritance) is not only useful in cases of mixed
-fixed-grid and flexible-grid DWDM network topology but also the only
-viable option in case of a mixed CWDM and DWDM network topology.
+Although not applicable to this document, it has been noted that being 
+able to use WSON and Flexi-grid topology models together (through 
+multi-inheritance) is not only useful for mixed fixed-grid and 
+flexible-grid DWDM network topologies but also the only viable option 
+for a mixed CWDM and DWDM network topology.
 
-Although not applicable to this document, it has been noted that the
-WDM tunnel model would support also optical tunnel setup in case of a
-mixed CWDM and DWDM network topology.
+Although not applicable to this document, it has been noted that the 
+WDM tunnel model would also support optical tunnel setup in the case 
+of a mixed CWDM and DWDM network topology.
 
-Although not analysed in this document, it has been noted that the TE
-Tunnel model, defined in {{!I-D.ietf-teas-yang-te}}, needs also to be enhanced to
-support scenarios where multiple parallel TE paths are used in load-balancing to carry the traffic between two end-points (e.g., VPN
+Although not analyzed in this document, it has been noted that the TE 
+Tunnel model, defined in {{!I-D.ietf-teas-yang-te}}, needs enhancement 
+to support scenarios where multiple parallel TE paths are used in 
+load-balancing to carry traffic between two end-points (e.g., VPN 
 traffic between two PEs).
 
 # Security Considerations {#security}
@@ -2053,41 +2206,101 @@ connectivity and resource requests.
 
 ## LLDP Snooping Security Considerations
 
-Earlier in the document, LLDP is discussed as a mechanism for the PNCs to discover the intra-domain Ethernet and IP links. While LLDP provides valuable information for network management and troubleshooting, it also presents several security issues:
+Earlier in the document, LLDP is discussed as a mechanism for the PNCs to
+discover the intra-domain Ethernet and IP links. While LLDP provides
+valuable information for network management and troubleshooting, it also
+presents several security issues:
 
-- Eavesdropping: LLDP transmissions are not encrypted. Potentially, LLDP packets could be captured using a packet sniffer. An attacker can leverage this information to gain insights into the network topology, device types, and configurations, which could be used for further attacks;
+- Eavesdropping: LLDP transmissions are not encrypted. Potentially, LLDP
+packets could be captured using a packet sniffer. An attacker can
+leverage this information to gain insights into the network topology,
+device types, and configurations, which could be used for further
+attacks;
 
-- Unauthorized Access: Information disclosed by LLDP can include device types, software versions, and network configuration details. This might help an attacker identify vulnerable devices or configurations that can be exploited to gain unauthorized access or escalate privileges within the network;
+- Unauthorized Access: Information disclosed by LLDP can include device
+types, software versions, and network configuration details. This might
+help an attacker identify vulnerable devices or configurations that can
+be exploited to gain unauthorized access or escalate privileges within
+the network;
 
-- Data Manipulation: If an attacker gains access to a network device, they could manipulate LLDP information to advertise false device information, leading to potential misconfigurations or trust relationships being exploited. This can disrupt network operations or redirect traffic to malicious devices;
+- Data Manipulation: If an attacker gains access to a network device,
+they could manipulate LLDP information to advertise false device
+information, leading to potential misconfigurations or trust
+relationships being exploited. This can disrupt network operations or
+redirect traffic to malicious devices;
 
-- Denial of Service (DoS): By flooding the network with fake LLDP packets, an attacker could overwhelm network devices or management systems, potentially leading to a denial of service where legitimate network traffic is disrupted;
+- Denial of Service (DoS): By flooding the network with fake LLDP
+packets, an attacker could overwhelm network devices or management
+systems, potentially leading to a denial of service where legitimate
+network traffic is disrupted;
 
-- Spoofing: An attacker could spoof LLDP packets to impersonate other network devices. Potentially, this might lead to incorrect network mappings or trust relationships being established with malicious devices;
+- Spoofing: An attacker could spoof LLDP packets to impersonate other
+network devices. Potentially, this might lead to incorrect network
+mappings or trust relationships being established with malicious devices;
 
-- Lack of Authentication: LLDP does not include mechanisms for authenticating the source of LLDP messages, which means that devices accept LLDP information from any source as legitimate.
+- Lack of Authentication: LLDP does not include mechanisms for
+authenticating the source of LLDP messages, which means that devices
+accept LLDP information from any source as legitimate.
 
-To mitigate these security issues, network administrators might implement several security measures, including:
+To mitigate these security issues, network administrators might implement
+several security measures, including:
 
-- Disabling LLDP on ports where it is not needed, especially those facing untrusted networks;
+- Disabling LLDP on ports where it is not needed, especially those facing
+untrusted networks;
 
-- Using network segmentation and Access Control Lists (ACLs) to limit who can send and receive LLDP packets;
+- Using network segmentation and Access Control Lists (ACLs) to limit who
+can send and receive LLDP packets;
 
-- Employing network monitoring and anomaly detection systems to identify unusual LLDP traffic patterns that may indicate an attack;
+- Employing network monitoring and anomaly detection systems to identify
+unusual LLDP traffic patterns that may indicate an attack;
 
-- Regularly updating and patching network devices to address known vulnerabilities that could be exploited through information gathered via LLDP.
+- Regularly updating and patching network devices to address known
+vulnerabilities that could be exploited through information gathered via
+LLDP.
 
 # Operational Considerations
 
-This document has identified the need and enabling components for automating the management and control of multi-layer Service Providers' transport networks, combining the optical and microwave transport layer with the packet (IP/MPLS) layer to create a more efficient and scalable network infrastructure. This approach is particularly beneficial for Service Providers and large enterprises dealing with high bandwidth demands and looking for cost-effective ways to expand their networks. However, integrating these two traditionally separate network layers involves several operational considerations:
+This document has identified the need and enabling components for
+automating the management and control of multi-layer Service Providers'
+transport networks, combining the optical and microwave transport layer
+with the packet (IP/MPLS) layer to create a more efficient and scalable
+network infrastructure. This approach is particularly beneficial for
+Service Providers and large enterprises dealing with high bandwidth
+demands and looking for cost-effective ways to expand their networks.
+However, integrating these two traditionally separate network layers
+involves several operational considerations:
 
-- Network Design and Capacity Planning: Deciding the degree of integration between the packet and optical layers is critical. Furthermore, this includes determining whether to pursue a loose integration (keeping layers distinct but coordinated) or a tight integration (combining layers more closely, potentially at the hardware level) coordinated via the MDSC. Accurate forecasting and planning will also be essential to ensure that the integrated ACTN infrastructure can handle future capacity demand without excessive over-provisioning;
+- Network Design and Capacity Planning: Deciding the degree of
+integration between the packet and optical layers is critical.
+Furthermore, this includes determining whether to pursue a loose
+integration (keeping layers distinct but coordinated) or a tight
+integration (combining layers more closely, potentially at the hardware
+level) coordinated via the MDSC. Accurate forecasting and planning will
+also be essential to ensure that the integrated ACTN infrastructure can
+handle future capacity demand without excessive over-provisioning;
 
-- System Interoperability: Networks often comprise equipment from various vendors. Ensuring that packet and optical devices can interoperate seamlessly and the PNCs can manage them is crucial for a successful integration. The Service Provider must also check with the vendors to ensure they support the IETF-based technologies outlined in this document;
+- System Interoperability: Networks often comprise equipment from various
+vendors. Ensuring that packet and optical devices can interoperate
+seamlessly and the PNCs can manage them is crucial for a successful
+integration. The Service Provider must also check with the vendors to
+ensure they support the IETF-based technologies outlined in this
+document;
 
-- Performance Monitoring: The integrated POI network will require comprehensive monitoring solutions that can provide visibility to the PNCs across both packet and optical layers. Identifying and diagnosing issues may become more complex with integrated layers. Telemetry data may also be required to collect lower-layer networking health and consider network and service performance. This topic is further discussed in [ACTN Assurance];
+- Performance Monitoring: The integrated POI network will require
+comprehensive monitoring solutions that can provide visibility to the
+PNCs across both packet and optical layers. Identifying and diagnosing
+issues may become more complex with integrated layers. Telemetry data may
+also be required to collect lower-layer networking health and consider
+network and service performance. This topic is further discussed in [ACTN
+Assurance];
 
-- Fault Management and Recovery: The POI networks should be resilient, including considerations for automatic protection switching and fast reroute mechanisms that span both layers. Fault isolation and recovery may become more challenging, as issues in one layer can have cascading effects on the other. Effective fault management strategies must be in place to quickly identify and rectify such issues. This topic is further discussed in [ACTN Assurance];
+- Fault Management and Recovery: The POI networks should be resilient,
+including considerations for automatic protection switching and fast
+reroute mechanisms that span both layers. Fault isolation and recovery
+may become more challenging, as issues in one layer can have cascading
+effects on the other. Effective fault management strategies must be in
+place to quickly identify and rectify such issues. This topic is further
+discussed in [ACTN Assurance];
 
 Specific Security Considerations are discussed in {{security}}.
 
@@ -2131,23 +2344,30 @@ the CEs in the case of an operator managed service.
 
 ### MDSC NBI
 
-As explained in {{reference-network}}, the OSS/Orchestration layer can request
+As explained in {{reference-network}}, the OSS/Orchestration layer can
+request
 the MDSC to setup L2/L3VPN network services (with or without TE
 requirements).
 
-Although the OSS/Orchestration layer interface is usually operator-specific, typically it would be using a RESTCONF/YANG interface with
+Although the OSS/Orchestration layer interface is usually
+operator-specific, typically it would be using a RESTCONF/YANG interface
+with
 a more abstracted version of the MPI YANG data models used for
 network configuration (e.g. L3NM, L2NM).
 
-{{fig-service-request}} shows an example of possible control flow between the
+{{fig-service-request}} shows an example of possible control flow between
+the
 OSS/Orchestration layer and the MDSC to instantiate L2/L3 VPN network
-services, using the YANG data models under the definition in {{?I-D.ietf-teas-actn-vn-yang}},
-{{?RFC9291}}, {{?RFC9182}} and {{?I-D.ietf-teas-te-service-mapping-yang}}.
+services, using the YANG data models under the definition in
+{{?I-D.ietf-teas-actn-vn-yang}},
+{{?RFC9291}}, {{?RFC9182}} and
+{{?I-D.ietf-teas-te-service-mapping-yang}}.
 
 {::include ./figures/service-request.md}
 {: #fig-service-request title="Service Request Process"}
 
-- The VN YANG data model, defined in {{?I-D.ietf-teas-actn-vn-yang}}, whose primary focus is
+- The VN YANG data model, defined in {{?I-D.ietf-teas-actn-vn-yang}},
+whose primary focus is
 the CMI, can also provide VN Service configuration from an
 orchestrated network service point of view when the L2/L3 VPN
 network service has TE requirements. However, this model is not
@@ -2170,7 +2390,8 @@ used to setup L2/L3 VPN service with no TE requirements.
 provide L2VPN and L3VPN network service configuration from a
 orchestrated connectivity service point of view.
 
-- The TE & Service Mapping YANG data model {{?I-D.ietf-teas-te-service-mapping-yang}} provides TE-service
+- The TE & Service Mapping YANG data model
+{{?I-D.ietf-teas-te-service-mapping-yang}} provides TE-service
 mapping.
 
 - TE-service mapping provides the mapping between a L2/L3 VPN
@@ -2202,7 +2423,8 @@ The focus is on client-side protection scheme between IP router and
 reconfigurable ROADM. Scenario here is to define only one port in the
 routers and in the ROADM muxponder board at both ends as back-up
 ports to recover any other port failure on client-side of the ROADM
-(either on the IP router port side or on the muxponder side or on the link
+(either on the IP router port side or on the muxponder side or on the
+link
 between them). When client-side port failure occurs, alarms are
 raised to MDSC by IP-PNC and O-PNC (port status down, LOS etc.). MDSC
 checks with OP-PNC(s) that there is no optical failure in the optical
@@ -2210,9 +2432,11 @@ layer.
 
 There can be two cases here:
 
-1. LAG was defined between the IP routers at the two ends. MDSC, after checking
+1. LAG was defined between the IP routers at the two ends. MDSC, after
+checking
 that optical layer is fine between the two edge WDM nodes, triggers
-the WDM edge node re-configuration so that the IP router's back-up port with its
+the WDM edge node re-configuration so that the IP router's back-up port
+with its
 associated muxponder port can reuse the WDM tunnel that was already in
 use previously by the failed IP router port and adds the new link to
 the LAG on the failure side.
@@ -2220,7 +2444,8 @@ the LAG on the failure side.
    While the ROADM reconfiguration takes place, IP/MPLS traffic is
    using the reduced bandwidth of the IP link bundle, discarding
    lower priority traffic if required. Once back-up port has been
-   reconfigured to reuse the existing WDM tunnel and the new link has been added
+   reconfigured to reuse the existing WDM tunnel and the new link has
+been added
    to the LAG then original Bandwidth is recovered between the end
    routers.
 
@@ -2297,7 +2522,8 @@ client port 2 on one muxponder can be connected only with client port
 In case of flexible configuration, since the two muxponders are under
 the control of the same O-PNC, the configuration of the multiplexing
 label, regardless of whether it is a standard or vendor-specific
-label, can be done by the O-PNC using mechanisms which are vendor-specific and outside the scope of this document. The MDSC can just
+label, can be done by the O-PNC using mechanisms which are
+vendor-specific and outside the scope of this document. The MDSC can just
 request the O-PNC to setup a client connectivity service over a WDM
 tunnel.
 
@@ -2306,7 +2532,8 @@ the muxponder but the O-PNC and MDSC needs to be aware of the
 connectivity constraints to avoid try and fail.
 
 It is worth noting that the current WSON and Flexi-grid topology
-models in {{!RFC9094}} and {{!I-D.ietf-ccamp-flexigrid-yang}} do not provide sufficient
+models in {{!RFC9094}} and {{!I-D.ietf-ccamp-flexigrid-yang}} do not
+provide sufficient
 information to the MDSC about this connectivity constraint and this
 is identified as a gap.
 
@@ -2317,6 +2544,7 @@ is identified as a gap.
 Some of this analysis work was supported in part by the European
 Commission funded H2020-ICT-2016-2 METRO-HAUL project (G.A. 761727).
 
-Previous versions of document were prepared using 2-Word-v2.0.template.dot.
+Previous versions of document were prepared using
+2-Word-v2.0.template.dot.
 
 This document was prepared using kramdown.


### PR DESCRIPTION
**[ACTN POI bi-weekly call (December 17, 2024)](https://github.com/IETF-TEAS-WG/actn-poi/wiki/minutes-2024-12-17)**

Comment 1: "(e.g., QSFP-DD ZR 400G)" Reference needed?
A1: Yes. Jeff was going to send it. 

- [x] @jbouqui153 : provide a reference for QSFP-DD ZR 400G

Comment 2: We seem to use WDM, CWDM and DWDM in the document; do we need all
of them, or can we use WDM or DWDM for consistency?   
A2: Yes. Mainly DWDM, unless special case for CWDM

Comment 3: "OSS/Orchestration layer" is not synonymous. 
A3: Actually, this 

Comment 4: Maybe provide a reference for the Shared Risk Link Group (SRLG) TE-path property?
A4: Yes. Italo to add. 

- [x] @italobusi provide a reference for Shared Risk Link Group (SRLG) TE-path property

Comment 6: Should "Service Access Points" contain a reference? 
A6 Yes, IETF SAP I-D. Italo to add.

- [x] @italobusi provide a reference for IETF SAP RFC

Comment 7: We need to double-check the usage of "setup" and "set up" based on the document, using them as verb phrases, nouns, or adjectives. I think I caught most of them. 
A7. Yes. Done. 

Comment 8: Need reference for PCEP?
A8. No. 

Comment 10: Long paragraphs. 
A10.  I've split long paragraphs and some very long sentences into new shorter sentences to enhance readability. 

Comment 12: Expand LTP on first use.
A12. Yes. Done. 

Comment 13: Expand LLDP on first use.
A13: Done. 

Comment 14: Expand RPC on first use, do we need a reference?
A14: I think not. 

Comment 15: Expand LAG and also reference.
A15. Done. Maybe use RFC8795 TE Topo as reference too, Italo can decide. 

- [x] @italobusi check reference for LAG

Comment 16: We say "This version of the draft", do we mean "This document assumes"
A16: Fixed. 
